### PR TITLE
Creation of a project settings window for selecting the tool chain as the cornerstone for enabling one-click builds

### DIFF
--- a/src/OneWare.UniversalFpgaProjectSystem/UniversalFpgaProjectManager.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/UniversalFpgaProjectManager.cs
@@ -106,6 +106,11 @@ public class UniversalFpgaProjectManager : IProjectManager
                         Command = new AsyncRelayCommand(() => _projectExplorerService.ReloadAsync(root)),
                         IconObservable = Application.Current!.GetResourceObservable("VsImageLib.RefreshGrey16X")
                     });
+                    menuItems.Add(new MenuItemViewModel("EditUI")
+                    {
+                        Header = "Edit",
+                        Command = new RelayCommand(() => _ = CreateFolderDialogAsync(root))
+                    });
                     menuItems.Add(new MenuItemViewModel("Edit")
                     {
                         Header = $"Edit {Path.GetFileName(root.ProjectFilePath)}",
@@ -189,5 +194,16 @@ public class UniversalFpgaProjectManager : IProjectManager
 
                     break;
             }
+    }
+    
+    public async Task CreateFolderDialogAsync(UniversalFpgaProjectRoot root)
+    {
+        // UniversalFpgaProjectRoot root
+        await _windowService.ShowDialogAsync(new UniversalFpgaProjectSettingsEditorView()
+        {
+            DataContext = new UniversalFpgaProjectSettingsEditorViewModel(root)
+                /* ContainerLocator.Container.Resolve<UniversalFpgaProjectSettingsEditorViewModel>() */
+        });
+        
     }
 }

--- a/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
@@ -1,0 +1,91 @@
+using System.Collections.ObjectModel;
+using System.Text.Json.Nodes;
+using System.Windows.Input;
+using Avalonia.Controls;
+using DynamicData;
+using OneWare.Essentials.Controls;
+using OneWare.Essentials.Models;
+using OneWare.Essentials.Services;
+using OneWare.Settings.ViewModels.SettingTypes;
+using OneWare.Settings.Views.SettingTypes;
+using OneWare.UniversalFpgaProjectSystem.Models;
+using OneWare.UniversalFpgaProjectSystem.Services;
+using Prism.Ioc;
+using ReactiveUI;
+
+namespace OneWare.UniversalFpgaProjectSystem.ViewModels;
+
+public class UniversalFpgaProjectSettingsEditorViewModel : ReactiveObject
+{
+    public string Title { get; set; } = "Test";
+    
+    public List<UserControl> UserControlsList { get; }
+
+    private UniversalFpgaProjectRoot _root;
+
+    private ComboBoxSetting _toolchain;
+    private ComboBoxSetting _loader;
+
+    private ListBoxSetting _includesSettings;
+    private ListBoxSetting _excludesSettings;
+    
+    public UniversalFpgaProjectSettingsEditorViewModel(UniversalFpgaProjectRoot root)
+    {
+        _root = root;
+        Title = $"{_root.Name} Settings";
+        
+        var includes = _root.Properties["Include"]!.AsArray().Select(node => node!.ToString()).ToArray();
+        var exclude = _root.Properties["Exclude"]!.AsArray().Select(node => node!.ToString()).ToArray();
+        
+        var toolchains = ContainerLocator.Container.Resolve<FpgaService>().Toolchains.Select(toolchain => toolchain.Name);
+        var currentToolchain = _root.Properties["Toolchain"]!.ToString();
+        _toolchain = new ComboBoxSetting("Toolchain", "test", currentToolchain, toolchains);
+        
+        var loader = ContainerLocator.Container.Resolve<FpgaService>().Loaders.Select(loader => loader.Name);
+        var currentLoader = _root.Properties["Loader"]!.ToString();
+        _loader = new ComboBoxSetting("Loader", "test", currentLoader, loader);
+
+        _includesSettings = new ListBoxSetting("Files to Include", "test", includes);
+        _excludesSettings = new ListBoxSetting("Files to Exclude", "test", exclude);
+        
+        UserControlsList = new List<UserControl>
+        {
+            new ComboBoxSettingView() {DataContext = new ComboBoxSettingViewModel(_toolchain) },
+            new ComboBoxSettingView() {DataContext = new ComboBoxSettingViewModel(_loader) },
+            new ListBoxSettingView() { DataContext = new ListBoxSettingViewModel(_includesSettings) },
+            new ListBoxSettingView() { DataContext = new ListBoxSettingViewModel(_excludesSettings) }
+        };
+    }
+
+    private async Task SaveAsync()
+    {
+        _root.Properties["Toolchain"] = _toolchain.Value.ToString();
+        _root.Properties["Loader"] = _loader.Value.ToString();
+        
+        UpdateJsonArray(_root.Properties["Include"]!, _includesSettings.Items.Select(item => item.ToString()).ToArray());
+        UpdateJsonArray(_root.Properties["Exclude"]!, _excludesSettings.Items.Select(item => item.ToString()).ToArray());
+        
+        await ContainerLocator.Container.Resolve<IProjectExplorerService>().SaveProjectAsync(_root);
+    }
+
+    private void UpdateJsonArray(JsonNode? jsonObject, string[] newValues)
+    {
+        jsonObject?.AsArray().Clear();
+        foreach (var value in newValues)
+        {
+            jsonObject?.AsArray().Add(value);
+        }
+    }
+    
+    public async Task SaveAndCloseAsync(FlexibleWindow window)
+    {
+        await SaveAsync();
+        Close(window);
+    }
+    
+    
+    public void Close(FlexibleWindow window)
+    {
+        window.Close();
+    }
+}

--- a/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectToolBarViewModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectToolBarViewModel.cs
@@ -92,7 +92,6 @@ public class UniversalFpgaProjectToolBarViewModel : ObservableObject
 
     public async Task CompileAsync()
     {
-         // _project.RunToolchainAsync();
         if (ProjectExplorerService.ActiveProject is UniversalFpgaProjectRoot project)
         {
             var name = project.Properties["Fpga"]?.ToString();
@@ -109,8 +108,6 @@ public class UniversalFpgaProjectToolBarViewModel : ObservableObject
 
             await project.RunToolchainAsync(new FpgaModel(firstOrDefault.LoadFpga()));
         }
-
-            
     }
     
     public async Task OpenPcfCreatorAsync()
@@ -124,6 +121,17 @@ public class UniversalFpgaProjectToolBarViewModel : ObservableObject
             });
     }
 
+    public async Task OpenProjectSettingsAsync()
+    {
+        if (ProjectExplorerService.ActiveProject is UniversalFpgaProjectRoot project)
+            await _windowService.ShowDialogAsync(new UniversalFpgaProjectSettingsEditorView()
+            {
+                DataContext =
+                    ContainerLocator.Container.Resolve<UniversalFpgaProjectSettingsEditorViewModel>((
+                        typeof(UniversalFpgaProjectRoot), project))
+            });
+    }
+    
     public async Task DownloadAsync()
     {
         if (ProjectExplorerService.ActiveProject is UniversalFpgaProjectRoot { Loader: not null } project)

--- a/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectToolBarViewModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectToolBarViewModel.cs
@@ -92,6 +92,29 @@ public class UniversalFpgaProjectToolBarViewModel : ObservableObject
 
     public async Task CompileAsync()
     {
+         // _project.RunToolchainAsync();
+        if (ProjectExplorerService.ActiveProject is UniversalFpgaProjectRoot project)
+        {
+            var name = project.Properties["Fpga"]?.ToString();
+            if (name == null) {
+                await OpenPcfCreatorAsync();
+                return;
+            }
+            
+            var firstOrDefault = FpgaService.FpgaPackages.FirstOrDefault(obj => obj.Name == name);
+            if (firstOrDefault == null) {
+                await OpenPcfCreatorAsync();
+                return;
+            }
+
+            await project.RunToolchainAsync(new FpgaModel(firstOrDefault.LoadFpga()));
+        }
+
+            
+    }
+    
+    public async Task OpenPcfCreatorAsync()
+    {
         if (ProjectExplorerService.ActiveProject is UniversalFpgaProjectRoot project)
             await _windowService.ShowDialogAsync(new UniversalFpgaProjectCompileView
             {

--- a/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectToolBarViewModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectToolBarViewModel.cs
@@ -96,13 +96,13 @@ public class UniversalFpgaProjectToolBarViewModel : ObservableObject
         {
             var name = project.Properties["Fpga"]?.ToString();
             if (name == null) {
-                await OpenPcfCreatorAsync();
+                await OpenPinPlannerAsync();
                 return;
             }
             
             var firstOrDefault = FpgaService.FpgaPackages.FirstOrDefault(obj => obj.Name == name);
             if (firstOrDefault == null) {
-                await OpenPcfCreatorAsync();
+                await OpenPinPlannerAsync();
                 return;
             }
 
@@ -110,7 +110,7 @@ public class UniversalFpgaProjectToolBarViewModel : ObservableObject
         }
     }
     
-    public async Task OpenPcfCreatorAsync()
+    public async Task OpenPinPlannerAsync()
     {
         if (ProjectExplorerService.ActiveProject is UniversalFpgaProjectRoot project)
             await _windowService.ShowDialogAsync(new UniversalFpgaProjectCompileView

--- a/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectSettingsEditorView.axaml
+++ b/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectSettingsEditorView.axaml
@@ -1,0 +1,51 @@
+<controls:FlexibleWindow xmlns="https://github.com/avaloniaui"
+                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                         xmlns:viewModels="clr-namespace:OneWare.UniversalFpgaProjectSystem.ViewModels"
+                         xmlns:controls="clr-namespace:OneWare.Essentials.Controls;assembly=OneWare.Essentials"
+                         mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450"
+                         PrefHeight="450" PrefWidth="600" Padding="4"
+                         WindowBackground="{DynamicResource ThemeBackgroundBrush}"
+                         WindowStartupLocation="CenterOwner"
+                         Title="{Binding Title}"
+                         CustomIcon="{DynamicResource CreateIcon}"
+                         x:Class="OneWare.UniversalFpgaProjectSystem.Views.UniversalFpgaProjectSettingsEditorView"
+                         x:DataType="viewModels:UniversalFpgaProjectSettingsEditorViewModel"
+                         Name="UniversalFpgaProjectCompileViewView">
+    <DockPanel>
+        <StackPanel>
+            <ContentControl DockPanel.Dock="Top">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <ItemsControl ItemsSource="{Binding UserControlsList}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Vertical"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Margin="0,10,0,50">
+                                    <ContentPresenter Content="{Binding}" />
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    
+                </ScrollViewer>
+            </ContentControl>
+            
+            <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="8" Classes="WindowButtons" HorizontalAlignment="Right"
+                        VerticalAlignment="Bottom">
+                <Button Command="{Binding SaveAndCloseAsync}"
+                        CommandParameter="{Binding #UniversalFpgaProjectCompileViewView}">
+                    <TextBlock Text="Save and Close" Margin="5 0" />
+                </Button>
+                <Button Command="{Binding Close}"
+                        CommandParameter="{Binding #UniversalFpgaProjectCompileViewView}">
+                    <TextBlock Text="Close" Margin="5 0" />
+                </Button>
+            </StackPanel>
+        </StackPanel>
+    </DockPanel>
+</controls:FlexibleWindow>

--- a/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectSettingsEditorView.axaml.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectSettingsEditorView.axaml.cs
@@ -1,0 +1,14 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using OneWare.Essentials.Controls;
+
+namespace OneWare.UniversalFpgaProjectSystem.Views;
+
+public partial class UniversalFpgaProjectSettingsEditorView : FlexibleWindow
+{
+    public UniversalFpgaProjectSettingsEditorView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectToolBarView.axaml
+++ b/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectToolBarView.axaml
@@ -25,18 +25,13 @@
             <Button.Flyout>
                 <Flyout FlyoutPresenterTheme="{StaticResource FlyoutNoPadding}">
                     <StackPanel>
-                        <Button  HorizontalContentAlignment="Left" Content="Open PCF Creator" 
-                                 Command="{Binding OpenPcfCreatorAsync}"
+                        <Button  HorizontalContentAlignment="Left" Content="Open Pin Planner" 
+                                 Command="{Binding OpenPinPlannerAsync}"
                                  />
                         <Button  HorizontalContentAlignment="Left" Content="Open Project Settings" 
                                  Command="{Binding OpenProjectSettingsAsync}"
                         />
-                        <Border Background="Gray" Height="1" Margin="0,10"/>
-                        <Button  HorizontalContentAlignment="Left" Content="Execute Synthesis"/>
-                        <Button  HorizontalContentAlignment="Left" Content="Execute Place and Route"/>
                     </StackPanel>
-                    
-                        
                 </Flyout>
             </Button.Flyout>
             <Image Source="{DynamicResource MaterialDesign.KeyboardArrowDown}" Width="10" Height="10" Margin="1 0" />

--- a/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectToolBarView.axaml
+++ b/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectToolBarView.axaml
@@ -28,6 +28,9 @@
                         <Button  HorizontalContentAlignment="Left" Content="Open PCF Creator" 
                                  Command="{Binding OpenPcfCreatorAsync}"
                                  />
+                        <Button  HorizontalContentAlignment="Left" Content="Open Project Settings" 
+                                 Command="{Binding OpenProjectSettingsAsync}"
+                        />
                         <Border Background="Gray" Height="1" Margin="0,10"/>
                         <Button  HorizontalContentAlignment="Left" Content="Execute Synthesis"/>
                         <Button  HorizontalContentAlignment="Left" Content="Execute Place and Route"/>

--- a/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectToolBarView.axaml
+++ b/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectToolBarView.axaml
@@ -24,28 +24,16 @@
         <Button>
             <Button.Flyout>
                 <Flyout FlyoutPresenterTheme="{StaticResource FlyoutNoPadding}">
-                    <ItemsControl ItemsSource="{Binding FpgaService.Toolchains}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate x:DataType="services:IFpgaToolchain">
-                                <MenuItem Header="{Binding Name}"
-                                          Command="{Binding $parent[UserControl].((viewModels:UniversalFpgaProjectToolBarViewModel)DataContext).ToggleProjectToolchain, FallbackValue={x:Null}}"
-                                          CommandParameter="{Binding}">
-                                    <MenuItem.Icon>
-                                        <CheckBox BorderThickness="0">
-                                            <CheckBox.IsChecked>
-                                                <MultiBinding
-                                                    Converter="{x:Static converters:SharedConverters.ObjectsEqualConverter}">
-                                                    <Binding FallbackValue="{x:Null}"
-                                                             Path="$parent[UserControl].((viewModels:UniversalFpgaProjectToolBarViewModel)DataContext).ProjectExplorerService.((models:UniversalFpgaProjectRoot)ActiveProject).Toolchain"/>
-                                                    <Binding />
-                                                </MultiBinding>
-                                            </CheckBox.IsChecked>
-                                        </CheckBox>
-                                    </MenuItem.Icon>
-                                </MenuItem>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
+                    <StackPanel>
+                        <Button  HorizontalContentAlignment="Left" Content="Open PCF Creator" 
+                                 Command="{Binding OpenPcfCreatorAsync}"
+                                 />
+                        <Border Background="Gray" Height="1" Margin="0,10"/>
+                        <Button  HorizontalContentAlignment="Left" Content="Execute Synthesis"/>
+                        <Button  HorizontalContentAlignment="Left" Content="Execute Place and Route"/>
+                    </StackPanel>
+                    
+                        
                 </Flyout>
             </Button.Flyout>
             <Image Source="{DynamicResource MaterialDesign.KeyboardArrowDown}" Width="10" Height="10" Margin="1 0" />
@@ -66,35 +54,6 @@
                 </Grid>
                 <TextBlock Text="Download" VerticalAlignment="Center" />
             </StackPanel>
-        </Button>
-        <Button>
-            <Button.Flyout>
-                <Flyout FlyoutPresenterTheme="{StaticResource FlyoutNoPadding}">
-                    <ItemsControl ItemsSource="{Binding FpgaService.Loaders}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate x:DataType="services:IFpgaLoader">
-                                <MenuItem Header="{Binding Name}"
-                                          Command="{Binding $parent[UserControl].((viewModels:UniversalFpgaProjectToolBarViewModel)DataContext).ToggleProjectLoader, FallbackValue={x:Null}}"
-                                          CommandParameter="{Binding}">
-                                    <MenuItem.Icon>
-                                        <CheckBox BorderThickness="0">
-                                            <CheckBox.IsChecked>
-                                                <MultiBinding
-                                                    Converter="{x:Static converters:SharedConverters.ObjectsEqualConverter}">
-                                                    <Binding FallbackValue="{x:Null}"
-                                                             Path="$parent[UserControl].((viewModels:UniversalFpgaProjectToolBarViewModel)DataContext).ProjectExplorerService.((models:UniversalFpgaProjectRoot)ActiveProject).Loader"/>
-                                                    <Binding />
-                                                </MultiBinding>
-                                            </CheckBox.IsChecked>
-                                        </CheckBox>
-                                    </MenuItem.Icon>
-                                </MenuItem>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                </Flyout>
-            </Button.Flyout>
-            <Image Source="{DynamicResource MaterialDesign.KeyboardArrowDown}" Width="10" Height="10" Margin="1 0" />
         </Button>
         <Button>
             <Button.Flyout>


### PR DESCRIPTION
The Compile button now only opens the Compiler View under, bypasses. If all the requirements are met, it builds directly. 

In the project settings window, you can now add the tool chain and the includes / excludes. Right-click on the project and ‘Edit’. 

A better name than ‘PCF Creator’ should be considered, this would only be valid for yosys and a better arrangement of the GUI for the project settings window. 