### PR TITLE
Add waveform PointerPressed to set SelectedSignal in WaveFormViewer

### DIFF
--- a/src/OneWare.WaveFormViewer/ViewModels/WaveFormViewModel.cs
+++ b/src/OneWare.WaveFormViewer/ViewModels/WaveFormViewModel.cs
@@ -36,6 +36,8 @@ public class WaveFormViewModel : ObservableObject
 
     public ObservableCollection<WaveModel> Signals { get; } = [];
 
+    public WaveModel SelectedSignal;
+    
     /// <summary>
     ///     1 = 1 fs
     /// </summary>

--- a/src/OneWare.WaveFormViewer/Views/WaveFormView.axaml
+++ b/src/OneWare.WaveFormViewer/Views/WaveFormView.axaml
@@ -154,14 +154,14 @@
                     <DataTemplate x:DataType="models:WaveModel">
                         <DockPanel Background="Transparent" ContextMenu="{StaticResource WaveModelContextMenu}"
                                    Height="{DynamicResource LineHeight}">
-                            <Grid VerticalAlignment="Center" DockPanel.Dock="Left">
+                            <Grid VerticalAlignment="Center" DockPanel.Dock="Left" PointerPressed="OnSignalNameClicked" Background="Transparent">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition MinWidth="50" Width="*" />
                                     <ColumnDefinition Width="5" />
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock TextTrimming="CharacterEllipsis" Text="{Binding Signal.Name}"
-                                           ToolTip.Tip="{Binding Signal.Name}" PointerPressed="OnSignalNameClicked"/>
+                                           ToolTip.Tip="{Binding Signal.Name}" />
                                 <TextBlock Grid.Column="2" TextTrimming="CharacterEllipsis"
                                            FontFamily="{DynamicResource EditorFont}"
                                            ToolTip.Tip="{Binding MarkerValue}" Text="{Binding MarkerValue}"

--- a/src/OneWare.WaveFormViewer/Views/WaveFormView.axaml
+++ b/src/OneWare.WaveFormViewer/Views/WaveFormView.axaml
@@ -161,7 +161,7 @@
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
                                 <TextBlock TextTrimming="CharacterEllipsis" Text="{Binding Signal.Name}"
-                                           ToolTip.Tip="{Binding Signal.Name}" />
+                                           ToolTip.Tip="{Binding Signal.Name}" PointerPressed="OnSignalNameClicked"/>
                                 <TextBlock Grid.Column="2" TextTrimming="CharacterEllipsis"
                                            FontFamily="{DynamicResource EditorFont}"
                                            ToolTip.Tip="{Binding MarkerValue}" Text="{Binding MarkerValue}"

--- a/src/OneWare.WaveFormViewer/Views/WaveFormView.axaml.cs
+++ b/src/OneWare.WaveFormViewer/Views/WaveFormView.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 using OneWare.Essentials.Helpers;
+using OneWare.WaveFormViewer.Models;
 using OneWare.WaveFormViewer.ViewModels;
 
 namespace OneWare.WaveFormViewer.Views;
@@ -124,5 +125,13 @@ public partial class WaveFormView : UserControl
         if ((e.Source as Visual).FindAncestorOfType<ScrollViewer>() is not { Name: "SimPartScroll" }) return;
         _pointerPressed = false;
         SimulatorEffectsRenderer.SetPos(e.GetPosition(SimulatorEffectsRenderer).X, _pointerPressed);
+    }
+    
+    private void OnSignalNameClicked(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is TextBlock textBlock && textBlock.DataContext is WaveModel waveModel)
+        {
+            _viewModel.SelectedSignal = waveModel;
+        }
     }
 }

--- a/src/OneWare.WaveFormViewer/Views/WaveFormView.axaml.cs
+++ b/src/OneWare.WaveFormViewer/Views/WaveFormView.axaml.cs
@@ -129,7 +129,7 @@ public partial class WaveFormView : UserControl
     
     private void OnSignalNameClicked(object? sender, PointerPressedEventArgs e)
     {
-        if (sender is TextBlock textBlock && textBlock.DataContext is WaveModel waveModel)
+        if (sender is Grid grid && grid.DataContext is WaveModel waveModel)
         {
             _viewModel.SelectedSignal = waveModel;
         }


### PR DESCRIPTION
This PR features a new SelectedSignal attribute, to use via the shared OneWare.WaveFormViewer.
It registeres a PointerPressed on the Grid in `Views/WaveFormView.axaml`.