### PR TITLE
[Feature] Extensible project settings

### DIFF
--- a/src/OneWare.Essentials/Models/Setting.cs
+++ b/src/OneWare.Essentials/Models/Setting.cs
@@ -49,12 +49,19 @@ public abstract class TitledSetting : Setting
     public IObservable<bool>? IsEnabledObservable { get; init; }
     
     public IObservable<bool>? IsVisibleObservable { get; init; }
+
+    public abstract TitledSetting Clone();
 }
 
 public class CheckBoxSetting : TitledSetting
 {
     public CheckBoxSetting(string title, bool defaultValue) : base(title, defaultValue)
     {
+    }
+
+    public override TitledSetting Clone()
+    {
+        return new CheckBoxSetting(this.Title, (bool)this.DefaultValue);
     }
 }
 
@@ -66,6 +73,11 @@ public class TextBoxSetting : TitledSetting
     }
 
     public string? Watermark { get; }
+    
+    public override TitledSetting Clone()
+    {
+        return new TextBoxSetting(this.Title, (bool)this.DefaultValue, Watermark);
+    }
 }
 
 public class ComboBoxSetting : TitledSetting
@@ -76,6 +88,11 @@ public class ComboBoxSetting : TitledSetting
     }
     
     public object[] Options { get; }
+    
+    public override TitledSetting Clone()
+    {
+        return new ComboBoxSetting(this.Title, (bool)this.DefaultValue, Options);
+    }
 }
 
 public class ListBoxSetting : TitledSetting
@@ -88,6 +105,11 @@ public class ListBoxSetting : TitledSetting
     {
         get => (Value as ObservableCollection<string>)!;
         set => Value = value;
+    }
+
+    public override TitledSetting Clone()
+    {
+        return new ListBoxSetting(this.Title, (string[])this.DefaultValue);
     }
 }
 
@@ -109,6 +131,11 @@ public class SliderSetting : TitledSetting
     public double Max { get; }
 
     public double Step { get; }
+    
+    public override TitledSetting Clone()
+    {
+        return new SliderSetting(this.Title, (double)this.DefaultValue, Min, Max, Step);
+    }
 }
 
 public abstract class PathSetting : TextBoxSetting
@@ -119,6 +146,7 @@ public abstract class PathSetting : TextBoxSetting
         string? startDirectory, Func<string, bool>? checkPath) : base(title, defaultValue, watermark)
     {
         StartDirectory = startDirectory;
+        CheckPath = checkPath;
 
         if (checkPath != null)
         {
@@ -129,6 +157,8 @@ public abstract class PathSetting : TextBoxSetting
 
     public string? StartDirectory { get; }
     public bool CanVerify { get; }
+    
+    public Func<string, bool>? CheckPath { get; }
 
     public bool IsValid
     {
@@ -177,7 +207,12 @@ public class ColorSetting : TitledSetting
     public ColorSetting(string title, Color defaultValue) : base(title, defaultValue)
     {
         
-    }    
+    }
+
+    public override TitledSetting Clone()
+    {
+        return new ColorSetting(this.Title, (Color)this.DefaultValue);
+    }
 }
 
 public class ProjectSetting

--- a/src/OneWare.Essentials/Models/Setting.cs
+++ b/src/OneWare.Essentials/Models/Setting.cs
@@ -180,6 +180,18 @@ public class ColorSetting : TitledSetting
     }    
 }
 
+public class ProjectSetting
+{
+    public ProjectSetting(string key, TitledSetting setting)
+    {
+        this.Key = key;
+        this.Setting = setting;
+    }
+    
+    public string Key { get; }
+    public TitledSetting Setting { get; }
+}
+
 public abstract class CustomSetting : Setting
 {
     public CustomSetting(object defaultValue) : base(defaultValue)

--- a/src/OneWare.Essentials/Models/Setting.cs
+++ b/src/OneWare.Essentials/Models/Setting.cs
@@ -217,14 +217,17 @@ public class ColorSetting : TitledSetting
 
 public class ProjectSetting
 {
-    public ProjectSetting(string key, TitledSetting setting)
+    public ProjectSetting(string key, TitledSetting setting, Func<IProjectRootWithFile, bool> activationFunction)
     {
         this.Key = key;
         this.Setting = setting;
+        this.ActivationFunction = activationFunction;
     }
     
     public string Key { get; }
     public TitledSetting Setting { get; }
+    
+    public Func<IProjectRootWithFile, bool> ActivationFunction { get; }
 }
 
 public abstract class CustomSetting : Setting

--- a/src/OneWare.Essentials/Models/Setting.cs
+++ b/src/OneWare.Essentials/Models/Setting.cs
@@ -109,7 +109,7 @@ public class ListBoxSetting : TitledSetting
 
     public override TitledSetting Clone()
     {
-        return new ListBoxSetting(this.Title, (string[])this.DefaultValue);
+        return new ListBoxSetting(this.Title, ((ObservableCollection<string>)this.DefaultValue).ToArray());
     }
 }
 

--- a/src/OneWare.Essentials/Models/Setting.cs
+++ b/src/OneWare.Essentials/Models/Setting.cs
@@ -76,7 +76,7 @@ public class TextBoxSetting : TitledSetting
     
     public override TitledSetting Clone()
     {
-        return new TextBoxSetting(this.Title, (bool)this.DefaultValue, Watermark);
+        return new TextBoxSetting(this.Title, this.DefaultValue, Watermark);
     }
 }
 
@@ -91,7 +91,7 @@ public class ComboBoxSetting : TitledSetting
     
     public override TitledSetting Clone()
     {
-        return new ComboBoxSetting(this.Title, (bool)this.DefaultValue, Options);
+        return new ComboBoxSetting(this.Title, this.DefaultValue, Options);
     }
 }
 

--- a/src/OneWare.Essentials/Services/IProjectSettingsService.cs
+++ b/src/OneWare.Essentials/Services/IProjectSettingsService.cs
@@ -4,7 +4,7 @@ namespace OneWare.Essentials.Services;
 
 public interface IProjectSettingsService
 {
-    public void AddProjectSetting(string key, TitledSetting projectSetting);
+    public void AddProjectSetting(string key, TitledSetting projectSetting, Func<IProjectRootWithFile, bool> activationFunction);
     
     public void AddProjectSetting(ProjectSetting projectSetting);
 

--- a/src/OneWare.Essentials/Services/IProjectSettingsService.cs
+++ b/src/OneWare.Essentials/Services/IProjectSettingsService.cs
@@ -1,0 +1,16 @@
+﻿using OneWare.Essentials.Models;
+
+namespace OneWare.Essentials.Services;
+
+public interface IProjectSettingsService
+{
+    public void AddProjectSetting(string key, TitledSetting projectSetting);
+    
+    public void AddProjectSetting(ProjectSetting projectSetting);
+
+    public T[] GetComboOptions<T>(string key);
+
+    public void Load(string path);
+    
+    public void Save(string path);
+}

--- a/src/OneWare.Essentials/Services/IProjectSettingsService.cs
+++ b/src/OneWare.Essentials/Services/IProjectSettingsService.cs
@@ -8,11 +8,9 @@ public interface IProjectSettingsService
     
     public void AddProjectSetting(ProjectSetting projectSetting);
 
-    public T[] GetComboOptions<T>(string key);
-
     public void Load(string path);
     
     public void Save(string path);
     
-    public Dictionary<string, ProjectSetting> GetProjectSettingsDictionary();
+    public List<ProjectSetting> GetProjectSettingsList();
 }

--- a/src/OneWare.Essentials/Services/IProjectSettingsService.cs
+++ b/src/OneWare.Essentials/Services/IProjectSettingsService.cs
@@ -13,4 +13,6 @@ public interface IProjectSettingsService
     public void Load(string path);
     
     public void Save(string path);
+    
+    public Dictionary<string, ProjectSetting> GetProjectSettingsDictionary();
 }

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingService.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingService.cs
@@ -1,0 +1,34 @@
+﻿using OneWare.Essentials.Models;
+using OneWare.Essentials.Services;
+
+namespace OneWare.UniversalFpgaProjectSystem.Services;
+
+public class ProjectSettingService : IProjectSettingsService
+{
+    public Dictionary<string, ProjectSetting> ProjectSettings { get; } = new();
+    
+    public void AddProjectSetting(string key, TitledSetting projectSetting)
+    {
+        throw new NotImplementedException();
+    }
+    
+    public void AddProjectSetting(ProjectSetting projectSetting)
+    {
+        throw new NotImplementedException();
+    }
+
+    public T[] GetComboOptions<T>(string key)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Load(string path)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Save(string path)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingService.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingService.cs
@@ -5,16 +5,16 @@ namespace OneWare.UniversalFpgaProjectSystem.Services;
 
 public class ProjectSettingService : IProjectSettingsService
 {
-    public Dictionary<string, ProjectSetting> ProjectSettings { get; } = new();
+    public Dictionary<string, TitledSetting> ProjectSettings { get; } = new();
     
     public void AddProjectSetting(string key, TitledSetting projectSetting)
     {
-        throw new NotImplementedException();
+        AddProjectSetting(new ProjectSetting(key, projectSetting));
     }
     
     public void AddProjectSetting(ProjectSetting projectSetting)
     {
-        throw new NotImplementedException();
+        ProjectSettings.Add(projectSetting.Key, projectSetting.Setting);
     }
 
     public T[] GetComboOptions<T>(string key)

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingsService.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingsService.cs
@@ -5,7 +5,7 @@ namespace OneWare.UniversalFpgaProjectSystem.Services;
 
 public class ProjectSettingsService : IProjectSettingsService
 {
-    public Dictionary<string, TitledSetting> ProjectSettings { get; } = new();
+    public List<ProjectSetting> ProjectSettings { get; } = new();
     
     public void AddProjectSetting(string key, TitledSetting projectSetting)
     {
@@ -14,12 +14,7 @@ public class ProjectSettingsService : IProjectSettingsService
     
     public void AddProjectSetting(ProjectSetting projectSetting)
     {
-        ProjectSettings.Add(projectSetting.Key, projectSetting.Setting);
-    }
-
-    public T[] GetComboOptions<T>(string key)
-    {
-        throw new NotImplementedException();
+        ProjectSettings.Add(projectSetting);
     }
 
     public void Load(string path)
@@ -32,8 +27,15 @@ public class ProjectSettingsService : IProjectSettingsService
         throw new NotImplementedException();
     }
 
-    public Dictionary<string, ProjectSetting> GetProjectSettingsDictionary()
+    public List<ProjectSetting> GetProjectSettingsList()
     {
-        throw new NotImplementedException();
+        List<ProjectSetting> ret = new();
+        
+        foreach (var projectSetting in ProjectSettings)
+        {
+            ret.Add(new ProjectSetting(projectSetting.Key, projectSetting.Setting.Clone()));
+        }
+        
+        return ret;
     }
 }

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingsService.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingsService.cs
@@ -31,4 +31,9 @@ public class ProjectSettingService : IProjectSettingsService
     {
         throw new NotImplementedException();
     }
+
+    public Dictionary<string, ProjectSetting> GetProjectSettingsDictionary()
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingsService.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingsService.cs
@@ -7,9 +7,9 @@ public class ProjectSettingsService : IProjectSettingsService
 {
     public List<ProjectSetting> ProjectSettings { get; } = new();
     
-    public void AddProjectSetting(string key, TitledSetting projectSetting)
+    public void AddProjectSetting(string key, TitledSetting projectSetting, Func<IProjectRootWithFile, bool> activationFunction)
     {
-        AddProjectSetting(new ProjectSetting(key, projectSetting));
+        AddProjectSetting(new ProjectSetting(key, projectSetting, activationFunction));
     }
     
     public void AddProjectSetting(ProjectSetting projectSetting)
@@ -33,7 +33,7 @@ public class ProjectSettingsService : IProjectSettingsService
         
         foreach (var projectSetting in ProjectSettings)
         {
-            ret.Add(new ProjectSetting(projectSetting.Key, projectSetting.Setting.Clone()));
+            ret.Add(new ProjectSetting(projectSetting.Key, projectSetting.Setting.Clone(), projectSetting.ActivationFunction));
         }
         
         return ret;

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingsService.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingsService.cs
@@ -3,7 +3,7 @@ using OneWare.Essentials.Services;
 
 namespace OneWare.UniversalFpgaProjectSystem.Services;
 
-public class ProjectSettingService : IProjectSettingsService
+public class ProjectSettingsService : IProjectSettingsService
 {
     public Dictionary<string, TitledSetting> ProjectSettings { get; } = new();
     

--- a/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.Text.Json.Nodes;
 using System.Windows.Input;
 using Avalonia.Controls;
+using Avalonia.Media;
 using DynamicData;
 using OneWare.Essentials.Controls;
 using OneWare.Essentials.Models;
@@ -19,11 +20,11 @@ namespace OneWare.UniversalFpgaProjectSystem.ViewModels;
 public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewModelBase
 {
     private readonly IProjectExplorerService _projectExplorerService;
-    
+
     private readonly FpgaService _fpgaService;
-    
+
     private readonly IProjectSettingsService _projectSettingsService;
-    
+
     public SettingsCollectionViewModel SettingsCollection { get; } = new("")
     {
         ShowTitle = false
@@ -37,8 +38,12 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
 
     private ListBoxSetting _includesSettings;
     private ListBoxSetting _excludesSettings;
-    
-    public UniversalFpgaProjectSettingsEditorViewModel(UniversalFpgaProjectRoot root, IProjectExplorerService projectExplorerService, FpgaService fpgaService, IProjectSettingsService projectSettingsService)
+
+    private Dictionary<TitledSetting, string> _dynamicSettingsKeys = new();
+
+    public UniversalFpgaProjectSettingsEditorViewModel(UniversalFpgaProjectRoot root,
+        IProjectExplorerService projectExplorerService, FpgaService fpgaService,
+        IProjectSettingsService projectSettingsService, ILogger logger)
     {
         _root = root;
         _projectExplorerService = projectExplorerService;
@@ -52,36 +57,101 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
             var value = standard == null ? "" : standard.ToString();
             _vhdlStandard = new ComboBoxSetting("VHDL Standard", value, ["87", "93", "93c", "00", "02", "08", "19"]);
         }
-        
+
         var includes = _root.Properties["Include"]!.AsArray().Select(node => node!.ToString()).ToArray();
         var exclude = _root.Properties["Exclude"]!.AsArray().Select(node => node!.ToString()).ToArray();
-        
-        var toolchains = ContainerLocator.Container.Resolve<FpgaService>().Toolchains.Select(toolchain => toolchain.Name);
+
+        var toolchains = ContainerLocator.Container.Resolve<FpgaService>().Toolchains
+            .Select(toolchain => toolchain.Name);
         var currentToolchain = _root.Properties["Toolchain"]!.ToString();
         _toolchain = new ComboBoxSetting("Toolchain", currentToolchain, toolchains);
-        
+
         var loader = ContainerLocator.Container.Resolve<FpgaService>().Loaders.Select(loader => loader.Name);
         var currentLoader = _root.Properties["Loader"]!.ToString();
         _loader = new ComboBoxSetting("Loader", currentLoader, loader);
-    
+
         _includesSettings = new ListBoxSetting("Files to Include", includes);
         _excludesSettings = new ListBoxSetting("Files to Exclude", exclude);
-        
+
         SettingsCollection.SettingModels.Add(_toolchain);
         SettingsCollection.SettingModels.Add(_loader);
-        
-        if (_vhdlStandard != null) {
+
+        if (_vhdlStandard != null)
+        {
             SettingsCollection.SettingModels.Add(_vhdlStandard);
         }
-        
+
         SettingsCollection.SettingModels.Add(_includesSettings);
         SettingsCollection.SettingModels.Add(_excludesSettings);
 
-        /*foreach (ProjectSetting setting in _projectSettingsService.GetProjectSettingsDictionary().Values.)
+        foreach (ProjectSetting setting in _projectSettingsService.GetProjectSettingsList())
         {
-            TitledSetting localCopy = setting.Setting.
-        }*/
-        
+            TitledSetting localCopy = setting.Setting;
+
+            if (_root.Properties.AsObject().ContainsKey(setting.Key))
+            {
+                // load stored value
+
+                switch (localCopy.GetType().Name)
+                {
+                    case "CheckBoxSetting":
+                        localCopy = new CheckBoxSetting(localCopy.Title,
+                            _root.Properties[setting.Key]!.ToString() == "True" ? true : false);
+                        break;
+
+                    case "TextBoxSetting":
+                        localCopy = new TextBoxSetting(localCopy.Title, _root.Properties[setting.Key]!.AsObject(),
+                            ((TextBoxSetting)localCopy).Watermark);
+                        break;
+
+                    case "ComboBoxSetting":
+                        localCopy = new ComboBoxSetting(localCopy.Title, _root.Properties[setting.Key]!.AsObject(),
+                            ((ComboBoxSetting)localCopy).Options);
+                        break;
+
+                    case "ListBoxSetting":
+                        localCopy = new ListBoxSetting(localCopy.Title,
+                            _root.Properties[setting.Key]!.AsArray().Select(node => node!.ToString()).ToArray());
+                        break;
+
+                    case "ComboBoxSearchSetting":
+                        localCopy = new ComboBoxSearchSetting(localCopy.Title,
+                            _root.Properties[setting.Key]!.AsArray().Select(node => node!.ToString()).ToArray(),
+                            ((ComboBoxSearchSetting)localCopy).Options);
+                        break;
+
+                    case "SliderSetting":
+                        localCopy = new SliderSetting(localCopy.Title,
+                            (double)_root.Properties[setting.Key]!.AsObject(), ((SliderSetting)localCopy).Min,
+                            ((SliderSetting)localCopy).Max, ((SliderSetting)localCopy).Step);
+                        break;
+
+                    case "FolderPathSetting":
+                        localCopy = new FolderPathSetting(localCopy.Title,
+                            _root.Properties[setting.Key]!.AsObject().ToString(), ((FolderPathSetting)localCopy).Watermark,
+                            ((FolderPathSetting)localCopy).StartDirectory, ((FolderPathSetting)localCopy).CheckPath);
+                        break;
+
+                    case "FilePathSetting":
+                        localCopy = new FilePathSetting(localCopy.Title, _root.Properties[setting.Key]!.AsObject().ToString(), ((FilePathSetting)localCopy).Watermark, ((FilePathSetting)localCopy).StartDirectory, ((FilePathSetting)localCopy).CheckPath);
+                        break;
+
+                    case "ColorSetting":
+                        Color.TryParse(_root.Properties[setting.Key]!.AsObject().ToString(), out Color color);
+                        localCopy = new ColorSetting(localCopy.Title, color);
+                        break;
+
+                    default:
+
+                        logger.Error($"Unknown setting of type: {localCopy.GetType().Name}");
+                        continue;
+                }
+            }
+            
+            _dynamicSettingsKeys.Add(localCopy, setting.Key);
+
+            SettingsCollection.SettingModels.Add(localCopy);
+        }
     }
 
     private async Task SaveAsync()
@@ -89,21 +159,80 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
         var tcString = _toolchain.Value.ToString();
         if (tcString != null && _fpgaService.Toolchains.FirstOrDefault(x => x.Name == tcString) is { } tc)
             _root.Toolchain = tc;
-        
+
         var loaderString = _loader.Value.ToString();
         if (loaderString != null && _fpgaService.Loaders.FirstOrDefault(x => x.Name == loaderString) is { } loader)
             _root.Loader = loader;
-        
+
         _root.SetProjectPropertyArray("Include", _includesSettings.Items.Select(item => item.ToString()).ToArray());
         _root.SetProjectPropertyArray("Exclude", _excludesSettings.Items.Select(item => item.ToString()).ToArray());
-        
+
         if (_vhdlStandard?.Value.ToString() != null)
             _root.SetProjectProperty("VHDL_Standard", _vhdlStandard.Value.ToString()!);
+
+        foreach (var toSave in SettingsCollection.SettingModels)
+        {
+            if (toSave == _toolchain || toSave == _loader || toSave == _includesSettings ||
+                toSave == _excludesSettings || toSave == _vhdlStandard)
+            {
+                // Hardcoded; Skip for now
+                
+                continue;
+            }
+
+            if (toSave is not TitledSetting)
+            {
+                continue;
+            }
+
+            switch (toSave.GetType().Name)
+            {
+                case "CheckBoxSetting":
+                    _root.SetProjectProperty(_dynamicSettingsKeys[(toSave as TitledSetting)!], toSave.Value.ToString()!);
+                    break;
+                
+                case "TextBoxSetting":
+
+                    break;
+                
+                case "ComboBoxSetting":
+                    
+                    break;
+                
+                case "ListBoxSetting":
+                    
+                    break;
+                
+                case "ComboBoxSearchSetting":
+                    
+                    break;
+                
+                case "SliderSetting":
+                    
+                    break;
+                
+                case "FolderPathSetting":
+                    
+                    break;
+                
+                case "FilePathSetting":
+                    
+                    break;
+                
+                case "ColorSetting":
+                    
+                    break;
+                
+                default:
+                    // This should never happen
+                    break;
+            }
+        }
         
         await _projectExplorerService.SaveProjectAsync(_root);
         await _projectExplorerService.ReloadAsync(_root);
     }
-    
+
     public async Task SaveAndCloseAsync(FlexibleWindow window)
     {
         await SaveAsync();

--- a/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
@@ -82,6 +82,11 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
         {
             TitledSetting localCopy = setting.Setting;
 
+            if (setting.ActivationFunction(root) == false)
+            {
+                continue;
+            }
+
             if (_root.Properties.AsObject().ContainsKey(setting.Key))
             {
                 // load stored value

--- a/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
@@ -22,6 +22,8 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
     
     private readonly FpgaService _fpgaService;
     
+    private readonly IProjectSettingsService _projectSettingsService;
+    
     public SettingsCollectionViewModel SettingsCollection { get; } = new("")
     {
         ShowTitle = false
@@ -36,11 +38,12 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
     private ListBoxSetting _includesSettings;
     private ListBoxSetting _excludesSettings;
     
-    public UniversalFpgaProjectSettingsEditorViewModel(UniversalFpgaProjectRoot root, IProjectExplorerService projectExplorerService, FpgaService fpgaService)
+    public UniversalFpgaProjectSettingsEditorViewModel(UniversalFpgaProjectRoot root, IProjectExplorerService projectExplorerService, FpgaService fpgaService, IProjectSettingsService projectSettingsService)
     {
         _root = root;
         _projectExplorerService = projectExplorerService;
         _fpgaService = fpgaService;
+        _projectSettingsService = projectSettingsService;
         Title = $"{_root.Name} Settings";
 
         if (root.TopEntity != null && (root.TopEntity.Name.Contains("vhd") || root.TopEntity.Name.Contains("vhdl")))
@@ -73,6 +76,11 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
         
         SettingsCollection.SettingModels.Add(_includesSettings);
         SettingsCollection.SettingModels.Add(_excludesSettings);
+
+        /*foreach (ProjectSetting setting in _projectSettingsService.GetProjectSettingsDictionary().Values.)
+        {
+            TitledSetting localCopy = setting.Setting.
+        }*/
         
     }
 

--- a/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Avalonia.Media;
 using OneWare.Essentials.Controls;
 using OneWare.Essentials.Models;
@@ -115,7 +116,7 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
 
                     case "SliderSetting":
                         localCopy = new SliderSetting(localCopy.Title,
-                            (double)_root.Properties[setting.Key]!.AsValue(), ((SliderSetting)localCopy).Min,
+                            Double.Parse(_root.Properties[setting.Key]!.ToString(), CultureInfo.InvariantCulture), ((SliderSetting)localCopy).Min,
                             ((SliderSetting)localCopy).Max, ((SliderSetting)localCopy).Step);
                         break;
 

--- a/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
@@ -1,16 +1,9 @@
-using System.Collections.ObjectModel;
-using System.Text.Json.Nodes;
-using System.Windows.Input;
-using Avalonia.Controls;
 using Avalonia.Media;
-using DynamicData;
 using OneWare.Essentials.Controls;
 using OneWare.Essentials.Models;
 using OneWare.Essentials.Services;
 using OneWare.Essentials.ViewModels;
 using OneWare.Settings.ViewModels;
-using OneWare.Settings.ViewModels.SettingTypes;
-using OneWare.Settings.Views.SettingTypes;
 using OneWare.UniversalFpgaProjectSystem.Models;
 using OneWare.UniversalFpgaProjectSystem.Services;
 using Prism.Ioc;
@@ -100,12 +93,12 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
                         break;
 
                     case "TextBoxSetting":
-                        localCopy = new TextBoxSetting(localCopy.Title, _root.Properties[setting.Key]!.AsObject(),
+                        localCopy = new TextBoxSetting(localCopy.Title, _root.Properties[setting.Key]!.ToString(),
                             ((TextBoxSetting)localCopy).Watermark);
                         break;
 
                     case "ComboBoxSetting":
-                        localCopy = new ComboBoxSetting(localCopy.Title, _root.Properties[setting.Key]!.AsObject(),
+                        localCopy = new ComboBoxSetting(localCopy.Title, _root.Properties[setting.Key]!.ToString(),
                             ((ComboBoxSetting)localCopy).Options);
                         break;
 
@@ -122,22 +115,25 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
 
                     case "SliderSetting":
                         localCopy = new SliderSetting(localCopy.Title,
-                            (double)_root.Properties[setting.Key]!.AsObject(), ((SliderSetting)localCopy).Min,
+                            (double)_root.Properties[setting.Key]!.AsValue(), ((SliderSetting)localCopy).Min,
                             ((SliderSetting)localCopy).Max, ((SliderSetting)localCopy).Step);
                         break;
 
                     case "FolderPathSetting":
                         localCopy = new FolderPathSetting(localCopy.Title,
-                            _root.Properties[setting.Key]!.AsObject().ToString(), ((FolderPathSetting)localCopy).Watermark,
+                            _root.Properties[setting.Key]!.ToString(), ((FolderPathSetting)localCopy).Watermark,
                             ((FolderPathSetting)localCopy).StartDirectory, ((FolderPathSetting)localCopy).CheckPath);
                         break;
 
                     case "FilePathSetting":
-                        localCopy = new FilePathSetting(localCopy.Title, _root.Properties[setting.Key]!.AsObject().ToString(), ((FilePathSetting)localCopy).Watermark, ((FilePathSetting)localCopy).StartDirectory, ((FilePathSetting)localCopy).CheckPath);
+                        localCopy = new FilePathSetting(localCopy.Title,
+                            _root.Properties[setting.Key]!.ToString(),
+                            ((FilePathSetting)localCopy).Watermark, ((FilePathSetting)localCopy).StartDirectory,
+                            ((FilePathSetting)localCopy).CheckPath);
                         break;
 
                     case "ColorSetting":
-                        Color.TryParse(_root.Properties[setting.Key]!.AsObject().ToString(), out Color color);
+                        Color.TryParse(_root.Properties[setting.Key]!.ToString(), out Color color);
                         localCopy = new ColorSetting(localCopy.Title, color);
                         break;
 
@@ -147,7 +143,7 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
                         continue;
                 }
             }
-            
+
             _dynamicSettingsKeys.Add(localCopy, setting.Key);
 
             SettingsCollection.SettingModels.Add(localCopy);
@@ -176,7 +172,7 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
                 toSave == _excludesSettings || toSave == _vhdlStandard)
             {
                 // Hardcoded; Skip for now
-                
+
                 continue;
             }
 
@@ -188,47 +184,48 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
             switch (toSave.GetType().Name)
             {
                 case "CheckBoxSetting":
+                    _root.SetProjectProperty(_dynamicSettingsKeys[(toSave as TitledSetting)!],
+                        toSave.Value.ToString()!);
+                    break;
+
+                case "TextBoxSetting":
                     _root.SetProjectProperty(_dynamicSettingsKeys[(toSave as TitledSetting)!], toSave.Value.ToString()!);
                     break;
-                
-                case "TextBoxSetting":
 
-                    break;
-                
                 case "ComboBoxSetting":
-                    
+                    _root.SetProjectProperty(_dynamicSettingsKeys[(toSave as TitledSetting)!], toSave.Value.ToString()!);
                     break;
-                
+
                 case "ListBoxSetting":
-                    
+                    _root.SetProjectPropertyArray(_dynamicSettingsKeys[(toSave as TitledSetting)!], ((ListBoxSetting)toSave).Items.Select(item => item.ToString()).ToArray());
                     break;
-                
+
                 case "ComboBoxSearchSetting":
-                    
+                    _root.SetProjectProperty(_dynamicSettingsKeys[(toSave as TitledSetting)!], toSave.Value.ToString()!);
                     break;
-                
+
                 case "SliderSetting":
-                    
+                    _root.SetProjectProperty(_dynamicSettingsKeys[(toSave as TitledSetting)!], toSave.Value.ToString()!);
                     break;
-                
+
                 case "FolderPathSetting":
-                    
+                    _root.SetProjectProperty(_dynamicSettingsKeys[(toSave as TitledSetting)!], toSave.Value.ToString()!);
                     break;
-                
+
                 case "FilePathSetting":
-                    
+                    _root.SetProjectProperty(_dynamicSettingsKeys[(toSave as TitledSetting)!], toSave.Value.ToString()!);
                     break;
-                
+
                 case "ColorSetting":
-                    
+                    _root.SetProjectProperty(_dynamicSettingsKeys[(toSave as TitledSetting)!], ((Color) ((ColorSetting) toSave).Value).ToString());
                     break;
-                
+
                 default:
                     // This should never happen
                     break;
             }
         }
-        
+
         await _projectExplorerService.SaveProjectAsync(_root);
         await _projectExplorerService.ReloadAsync(_root);
     }

--- a/studio/OneWare.Studio/StudioApp.cs
+++ b/studio/OneWare.Studio/StudioApp.cs
@@ -7,6 +7,7 @@ using OneWare.CruviAdapterExtensions;
 using OneWare.Essentials.Services;
 using OneWare.Settings;
 using OneWare.UniversalFpgaProjectSystem;
+using OneWare.UniversalFpgaProjectSystem.Services;
 using OneWare.Vcd.Viewer;
 using Prism.Ioc;
 using Prism.Modularity;
@@ -16,6 +17,8 @@ namespace OneWare.Studio;
 public class StudioApp : App
 {
     public static readonly ISettingsService SettingsService = new SettingsService();
+
+    public static readonly IProjectSettingsService ProjectSettingsService = new ProjectSettingService();
 
     public static readonly IPaths Paths = new Paths("OneWare Studio", "avares://OneWare.Studio/Assets/icon.ico");
 
@@ -38,6 +41,7 @@ public class StudioApp : App
     protected override void RegisterTypes(IContainerRegistry containerRegistry)
     {
         containerRegistry.RegisterInstance(SettingsService);
+        containerRegistry.RegisterInstance(ProjectSettingsService);
         containerRegistry.RegisterInstance(Paths);
         containerRegistry.RegisterInstance(Logger);
 

--- a/studio/OneWare.Studio/StudioApp.cs
+++ b/studio/OneWare.Studio/StudioApp.cs
@@ -18,7 +18,7 @@ public class StudioApp : App
 {
     public static readonly ISettingsService SettingsService = new SettingsService();
 
-    public static readonly IProjectSettingsService ProjectSettingsService = new ProjectSettingService();
+    public static readonly IProjectSettingsService ProjectSettingsService = new ProjectSettingsService();
 
     public static readonly IPaths Paths = new Paths("OneWare Studio", "avares://OneWare.Studio/Assets/icon.ico");
 

--- a/studio/OneWare.Studio/StudioApp.cs
+++ b/studio/OneWare.Studio/StudioApp.cs
@@ -4,6 +4,7 @@ using OneWare.Core;
 using OneWare.Core.Data;
 using OneWare.Core.Services;
 using OneWare.CruviAdapterExtensions;
+using OneWare.Essentials.Models;
 using OneWare.Essentials.Services;
 using OneWare.Settings;
 using OneWare.UniversalFpgaProjectSystem;
@@ -36,6 +37,7 @@ public class StudioApp : App
             "Automatically download Binaries",
             "Automatically download binaries for features when possible", true);
         SettingsService.Load(Paths.SettingsPath);
+        ProjectSettingsService.AddProjectSetting("test", new CheckBoxSetting("blub", false));
     }
 
     protected override void RegisterTypes(IContainerRegistry containerRegistry)

--- a/studio/OneWare.Studio/StudioApp.cs
+++ b/studio/OneWare.Studio/StudioApp.cs
@@ -37,7 +37,6 @@ public class StudioApp : App
             "Automatically download Binaries",
             "Automatically download binaries for features when possible", true);
         SettingsService.Load(Paths.SettingsPath);
-        ProjectSettingsService.AddProjectSetting("test", new CheckBoxSetting("blub", false));
     }
 
     protected override void RegisterTypes(IContainerRegistry containerRegistry)


### PR DESCRIPTION
*What does this PR add?*

This PR enables both the OneWare Studio and any plugins to add project-specific settings at runtime. This complements the global settings menu and allows for more customization.

*Why is this needed?*

Using global settings to describe project-specific properties is inconvenient - for both the developer and the user. Allowing for the addition of project-specific settings at runtime is therefore necessary.

*Are there any limitations?*

This PR only allows for settings that derive from TitledSetting to be added to the project-specific settings. Custom settings can therefore **not** be added.