### PR TITLE
Rename key from api.nuget.org to nuget.org

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -5,7 +5,7 @@
     <!-- optional -->
     <clear />
     <!-- optional -->
-    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <!-- nightly feed
     <add key="avalonia-nightly" value="https://nuget-feed-nightly.avaloniaui.net/v3/index.json" protocolVersion="3" />
     -->


### PR DESCRIPTION
NuGet was unable to resolve packages, throwing [NU1100](https://learn.microsoft.com/bs-latn-ba/nuget/reference/errors-and-warnings/nu1100): `Unable to resolve 'Dependency (>= 1.0.0)' for 'TargetFramework'. The following source(s) were not considered: api.nuget.org`

Switching the key in the nuget.config file from `api.nuget.org` to `nuget.org` solved this problem.