### PR TITLE
Close filestreams to prevent file access conflicts

### DIFF
--- a/src/OneWare.UniversalFpgaProjectSystem/Parser/UniversalFpgaProjectParser.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Parser/UniversalFpgaProjectParser.cs
@@ -26,6 +26,8 @@ public static class UniversalFpgaProjectParser
             {
                 AllowTrailingCommas = true
             });
+            
+            stream.Close();
 
             var root = new UniversalFpgaProjectRoot(path, properties!.AsObject());
             return root;
@@ -45,6 +47,8 @@ public static class UniversalFpgaProjectParser
             {
                 stream.SetLength(0);
                 await JsonSerializer.SerializeAsync(stream, root.Properties, SerializerOptions);
+                
+                stream.Close();
             }
 
             root.LastSaveTime = DateTime.Now;

--- a/src/OneWare.UniversalFpgaProjectSystem/Parser/UniversalFpgaProjectParser.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Parser/UniversalFpgaProjectParser.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using Avalonia.Threading;
 using OneWare.Essentials.Services;
 using OneWare.UniversalFpgaProjectSystem.Models;
 using Prism.Ioc;
@@ -20,17 +21,18 @@ public static class UniversalFpgaProjectParser
     {
         try
         {
-            await using var stream = File.OpenRead(path);
-
-            var properties = await JsonNode.ParseAsync(stream, null, new JsonDocumentOptions
+            return await Dispatcher.UIThread.Invoke(async () =>
             {
-                AllowTrailingCommas = true
-            });
-            
-            stream.Close();
+                await using var stream = File.OpenRead(path);
 
-            var root = new UniversalFpgaProjectRoot(path, properties!.AsObject());
-            return root;
+                var properties = await JsonNode.ParseAsync(stream, null, new JsonDocumentOptions
+                {
+                    AllowTrailingCommas = true
+                });
+                
+                var root = new UniversalFpgaProjectRoot(path, properties!.AsObject());
+                return root;
+            });
         }
         catch (Exception e)
         {
@@ -43,13 +45,14 @@ public static class UniversalFpgaProjectParser
     {
         try
         {
-            await using (var stream = File.OpenWrite(root.ProjectFilePath))
+            await Dispatcher.UIThread.Invoke(async () =>
             {
-                stream.SetLength(0);
-                await JsonSerializer.SerializeAsync(stream, root.Properties, SerializerOptions);
-                
-                stream.Close();
-            }
+                await using (var stream = File.OpenWrite(root.ProjectFilePath))
+                {
+                    stream.SetLength(0);
+                    await JsonSerializer.SerializeAsync(stream, root.Properties, SerializerOptions);
+                }
+            });
 
             root.LastSaveTime = DateTime.Now;
 


### PR DESCRIPTION
# Updated description:

By using the UI Thread for file operations, file access violations are avoided.

## Old description:
By simple closing the filestreams opened in UniversalFpgaProjectParser.SerializeAsync() and UniversalFpgaProjectParser.DeserializeAsync(), the file access problem in #60 can be avoided.