### PR TITLE
bit width fix for waveform viewer

### DIFF
--- a/tests/OneWare.WaveFormViewer.Tests/SignalConverterTests.cs
+++ b/tests/OneWare.WaveFormViewer.Tests/SignalConverterTests.cs
@@ -8,9 +8,13 @@ public class SignalConverterTests
     [Fact]
     public void ConvertBitsToDecimalTests()
     {
-        Assert.Equal(-1000, SignalConverter.ConvertToSignedInt64("11111111111111111111110000011000", 32));
-        Assert.Equal(16191, SignalConverter.ConvertToSignedInt64("11111100111111", 32));
-        Assert.Equal(268434456, SignalConverter.ConvertToSignedInt64("00001111111111111111110000011000", 32));
+        Assert.Equal(4294966296, SignalConverter.ConvertToUnsignedInt("11111111111111111111110000011000"));
+        Assert.Equal(16191, SignalConverter.ConvertToUnsignedInt("11111100111111"));
+        Assert.Equal(268434456, SignalConverter.ConvertToUnsignedInt("00001111111111111111110000011000"));
+        
+        Assert.Equal(-1000, SignalConverter.ConvertToSignedInt("11111111111111111111110000011000"));
+        Assert.Equal(-193, SignalConverter.ConvertToSignedInt("11111100111111"));
+        Assert.Equal(268434456, SignalConverter.ConvertToSignedInt("00001111111111111111110000011000"));
     }
 
     [Fact]


### PR DESCRIPTION
related to issue 69

Fixes the related crash for vectors larger than 64 bits
https://github.com/one-ware/OneWare/issues/69

I changed the long type to bigInteger instead. Vectors in HDL can be arbitrarily long. Makes more sense to me to use a arbitrary length integer to contain the results too.