### PR TITLE
Fix: Textbox validation errors

### DIFF
--- a/src/OneWare.Essentials/Behaviors/ClearValidationErrorsLostFocusBehavior.cs
+++ b/src/OneWare.Essentials/Behaviors/ClearValidationErrorsLostFocusBehavior.cs
@@ -1,0 +1,51 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Xaml.Interactivity;
+
+namespace OneWare.Essentials.Behaviors;
+
+/// <summary>
+/// This behavior fixes the avalonia textbox bug, that the validation errors won't
+/// be cleared, if the new value equals the last valid input.
+/// </summary>
+public class ClearValidationErrorsLostFocusBehavior : Trigger<TextBox>
+{
+    public static readonly StyledProperty<string?> TextProperty =
+        AvaloniaProperty.Register<ClearValidationErrorsLostFocusBehavior, string?>(nameof(Text));
+    
+    public string? Text
+    {
+        get => GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+    
+    protected override void OnAttached()
+    {
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.LostFocus += OnLostFocus;
+        }
+        base.OnAttached();
+    }
+
+    protected override void OnDetaching()
+    {
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.LostFocus -= OnLostFocus;
+        }
+        base.OnDetaching();
+    }
+
+    private void OnLostFocus(object? sender, RoutedEventArgs e)
+    {
+        if (AssociatedObject == null) 
+            return;
+
+        if (DataValidationErrors.GetHasErrors(AssociatedObject) && AssociatedObject.Text == Text)
+        {
+            DataValidationErrors.ClearErrors(AssociatedObject);
+        }
+    }
+}

--- a/src/OneWare.Settings/Views/SettingTypes/SliderSettingView.axaml
+++ b/src/OneWare.Settings/Views/SettingTypes/SliderSettingView.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:settingTypes="clr-namespace:OneWare.Settings.ViewModels.SettingTypes"
              xmlns:mdxaml="https://github.com/whistyun/Markdown.Avalonia.Tight"
+             xmlns:behaviors="clr-namespace:OneWare.Essentials.Behaviors;assembly=OneWare.Essentials"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="OneWare.Settings.Views.SettingTypes.SliderSettingView"
              x:DataType="settingTypes:SliderSettingViewModel" IsVisible="{Binding Setting.IsVisibleObservable^, FallbackValue={x:True}}">
@@ -27,7 +28,12 @@
             <TextBox DockPanel.Dock="Right"
                      Width="100"
                      IsEnabled="{Binding Setting.IsEnabledObservable^, FallbackValue={x:True}}"
-                     Text="{Binding TextBoxValue}" />
+                     Text="{Binding TextBoxValue}" >
+                <Interaction.Behaviors>
+                    <behaviors:ClearValidationErrorsLostFocusBehavior Text="{Binding TextBoxValue, Mode=OneWay}">
+                    </behaviors:ClearValidationErrorsLostFocusBehavior>
+                </Interaction.Behaviors>
+            </TextBox>
             <Slider DockPanel.Dock="Left"
                     IsEnabled="{Binding Setting.IsEnabledObservable^, FallbackValue={x:True}}"
                     Minimum="{Binding Setting.Min}"


### PR DESCRIPTION
Fixed the OneWare.AI issue [#63 ](https://github.com/one-ware/OneWare.AI/issues/63)

The behavior clears the validation errors, if the Textbox.Text equals the property value.