### PR TITLE
Feature categories in project settings

### DIFF
--- a/src/OneWare.Essentials/Helpers/SettingBuilder.cs
+++ b/src/OneWare.Essentials/Helpers/SettingBuilder.cs
@@ -1,0 +1,59 @@
+using OneWare.Essentials.Models;
+
+namespace OneWare.Essentials.Helpers;
+
+public class ProjectSettingBuilder
+{
+    private string? _key;
+    private TitledSetting? _setting;
+    private Func<IProjectRootWithFile, bool>? _activationFunction;
+    private string? _category;
+    private int _displayOrder = 0;
+
+    public ProjectSettingBuilder WithKey(string key)
+    {
+        _key = key;
+        return this;
+    }
+
+    public ProjectSettingBuilder WithSetting(TitledSetting setting)
+    {
+        _setting = setting;
+        return this;
+    }
+
+    public ProjectSettingBuilder WithActivation(Func<IProjectRootWithFile, bool> activation)
+    {
+        _activationFunction = activation;
+        return this;
+    }
+
+    public ProjectSettingBuilder WithCategory(string category)
+    {
+        _category = category;
+        return this;
+    }
+
+    public ProjectSettingBuilder WithDisplayOrder(int displayOrder)
+    {
+        _displayOrder = displayOrder;
+        return this;
+    }
+
+    public ProjectSetting Build()
+    {
+        if (_key == null) throw new InvalidOperationException("Key must be provided.");
+        if (_setting == null) throw new InvalidOperationException("Setting must be provided.");
+        
+        _setting.Priority = _displayOrder;
+        _activationFunction ??= _ => true;
+
+        return new ProjectSetting(
+            _key,
+            _setting,
+            _activationFunction,
+            _category,
+            _displayOrder
+        );
+    }
+}

--- a/src/OneWare.Essentials/Models/Setting.cs
+++ b/src/OneWare.Essentials/Models/Setting.cs
@@ -12,6 +12,8 @@ public class Setting : ObservableObject
 {
     private object _value;
 
+    public int Priority { get; set; } = 0;
+
     public Setting(object defaultValue)
     {
         DefaultValue = defaultValue;
@@ -39,7 +41,7 @@ public abstract class TitledSetting : Setting
     {
         Title = title;
     }
-
+    
     public string Title { get; }
     
     public string? HoverDescription { get; init; }
@@ -215,27 +217,38 @@ public class ColorSetting : TitledSetting
     }
 }
 
-public class ProjectSetting
+public class ProjectSetting(
+    string key,
+    TitledSetting setting,
+    Func<IProjectRootWithFile, bool> activationFunction,
+    string? category = null,
+    int displayOrder = 0)
 {
-    public ProjectSetting(string key, TitledSetting setting, Func<IProjectRootWithFile, bool> activationFunction)
-    {
-        this.Key = key;
-        this.Setting = setting;
-        this.ActivationFunction = activationFunction;
-    }
+    public string Category { get; } = category ?? "General";
+
+    public string Key { get; } = key;
+    public TitledSetting Setting { get; } = setting;
+    public Func<IProjectRootWithFile, bool> ActivationFunction { get; } = activationFunction;
     
-    public string Key { get; }
-    public TitledSetting Setting { get; }
-    
-    public Func<IProjectRootWithFile, bool> ActivationFunction { get; }
+    /// <summary>
+    /// Determines the display priority of the setting in the UI.
+    /// Higher values appear further up in the list. Default is 0.
+    /// </summary>
+    public int DisplayOrder {get;} = 0;
+}
+
+
+public class CategorySetting(string key, string name)
+{
+    public string Key { get; } = key;
+    public string Name { get; } = name;
 }
 
 public abstract class CustomSetting : Setting
 {
+    public object? Control { get; init; }
     public CustomSetting(object defaultValue) : base(defaultValue)
     {
         
     }
-    
-    public object? Control { get; init; }
 }

--- a/src/OneWare.Essentials/Models/Setting.cs
+++ b/src/OneWare.Essentials/Models/Setting.cs
@@ -229,12 +229,6 @@ public class ProjectSetting(
     public string Key { get; } = key;
     public TitledSetting Setting { get; } = setting;
     public Func<IProjectRootWithFile, bool> ActivationFunction { get; } = activationFunction;
-    
-    /// <summary>
-    /// Determines the display priority of the setting in the UI.
-    /// Higher values appear further up in the list. Default is 0.
-    /// </summary>
-    public int DisplayOrder {get;} = 0;
 }
 
 

--- a/src/OneWare.Essentials/Services/IProjectSettingsService.cs
+++ b/src/OneWare.Essentials/Services/IProjectSettingsService.cs
@@ -4,13 +4,40 @@ namespace OneWare.Essentials.Services;
 
 public interface IProjectSettingsService
 {
+    [Obsolete("Use AddProjectSetting(ProjectSetting projectSetting) instead.")]
     public void AddProjectSetting(string key, TitledSetting projectSetting, Func<IProjectRootWithFile, bool> activationFunction);
     
+    /// <summary>
+    /// Adds an existing <see cref="ProjectSetting"/> instance.
+    /// </summary>
+    /// <param name="projectSetting">The project setting to add.</param>
     public void AddProjectSetting(ProjectSetting projectSetting);
 
+    public void AddProjectSettingIfNotExists(ProjectSetting projectSetting);
+    
     public void Load(string path);
     
     public void Save(string path);
     
     public List<ProjectSetting> GetProjectSettingsList();
+    
+    /// <summary>
+    /// Gets a list of all available project setting categories.
+    /// </summary>
+    /// <returns>A list of category names.</returns>
+    public List<string> GetProjectCategories();
+
+    /// <summary>
+    /// Gets a list of project settings belonging to the specified category.
+    /// </summary>
+    /// <param name="category">The category name to filter settings.</param>
+    /// <returns>A list of <see cref="ProjectSetting"/> instances in the specified category.</returns>
+    public List<ProjectSetting> GetProjectSettingsList(string category);
+    
+    /// <summary>
+    /// Returns the default category name used when no specific category is assigned to a project setting.
+    /// </summary>
+    /// <returns>The default category name as a string.</returns>
+    public string GetDefaultProjectCategory();
+    
 }

--- a/src/OneWare.Settings/ViewModels/SettingsCollectionViewModel.cs
+++ b/src/OneWare.Settings/ViewModels/SettingsCollectionViewModel.cs
@@ -30,7 +30,7 @@ public class SettingsCollectionViewModel : ObservableObject
 
         Application.Current.GetResourceObservable(iconKey).Subscribe(x => { Icon = x as IImage; });
     }
-
+    
     public bool ShowTitle { get; set; } = true;
     public IImage? Icon { get; set; }
 
@@ -83,5 +83,21 @@ public class SettingsCollectionViewModel : ObservableObject
                     break;
             }
         }
+        
+        var sorted = new ObservableCollection<SettingViewModel>(
+            SettingViewModels.OrderBy<SettingViewModel, int>(s => s.Setting.Priority) 
+        );
+        SettingViewModels.Clear();
+        foreach (var item in sorted)
+            SettingViewModels.Add(item);
+    }
+    
+    /// <summary>
+    /// Clears all settings and their view models.
+    /// </summary>
+    public void Clear()
+    {
+        SettingModels.Clear();
+        SettingViewModels.Clear();
     }
 }

--- a/src/OneWare.Settings/ViewModels/SettingsCollectionViewModel.cs
+++ b/src/OneWare.Settings/ViewModels/SettingsCollectionViewModel.cs
@@ -85,11 +85,11 @@ public class SettingsCollectionViewModel : ObservableObject
         }
         
         var sorted = new ObservableCollection<SettingViewModel>(
-            SettingViewModels.OrderBy<SettingViewModel, int>(s => s.Setting.Priority) 
+            SettingViewModels.OrderBy(s => s.Setting.Priority) 
         );
         SettingViewModels.Clear();
-        foreach (var item in sorted)
-            SettingViewModels.Add(item);
+        SettingViewModels.AddRange(sorted);
+
     }
     
     /// <summary>

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingsService.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingsService.cs
@@ -6,15 +6,53 @@ namespace OneWare.UniversalFpgaProjectSystem.Services;
 public class ProjectSettingsService : IProjectSettingsService
 {
     public List<ProjectSetting> ProjectSettings { get; } = new();
+    private Dictionary<string, List<ProjectSetting>> ProjectSettingsByCategory { get; } = new();
     
+    /// <inheritdoc/>
     public void AddProjectSetting(string key, TitledSetting projectSetting, Func<IProjectRootWithFile, bool> activationFunction)
     {
         AddProjectSetting(new ProjectSetting(key, projectSetting, activationFunction));
     }
     
+    /// <inheritdoc/>
     public void AddProjectSetting(ProjectSetting projectSetting)
     {
         ProjectSettings.Add(projectSetting);
+
+        if (!ProjectSettingsByCategory.TryGetValue(projectSetting.Category, out List<ProjectSetting>? value))
+        {
+            value = [];
+            ProjectSettingsByCategory[projectSetting.Category] = value;
+        }
+
+        value.Add(projectSetting);
+    }
+
+    public void AddProjectSettingIfNotExists(ProjectSetting projectSetting)
+    {
+        if (ProjectSettings.All(x => x.Key != projectSetting.Key))
+        {
+            AddProjectSetting(projectSetting);
+        }
+    }
+
+    /// <inheritdoc/>
+    public List<string> GetProjectCategories()
+    {
+        return ProjectSettingsByCategory.Keys.ToList();
+    }
+    
+    /// <inheritdoc/>
+    public List<ProjectSetting> GetProjectSettingsList(string category)
+    {
+        return ProjectSettingsByCategory[category]
+            .OrderByDescending(s => s.DisplayOrder)
+            .ThenBy(s => s.Key, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    public string GetDefaultProjectCategory()
+    {
+        return "General";
     }
 
     public void Load(string path)
@@ -38,4 +76,6 @@ public class ProjectSettingsService : IProjectSettingsService
         
         return ret;
     }
+    
+    
 }

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingsService.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingsService.cs
@@ -45,9 +45,7 @@ public class ProjectSettingsService : IProjectSettingsService
     /// <inheritdoc/>
     public List<ProjectSetting> GetProjectSettingsList(string category)
     {
-        return ProjectSettingsByCategory[category]
-            .OrderByDescending(s => s.DisplayOrder)
-            .ThenBy(s => s.Key, StringComparer.OrdinalIgnoreCase).ToList();
+        return ProjectSettingsByCategory[category];
     }
 
     public string GetDefaultProjectCategory()

--- a/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
@@ -1,6 +1,8 @@
+using System.Collections.ObjectModel;
 using System.Globalization;
 using Avalonia.Media;
 using OneWare.Essentials.Controls;
+using OneWare.Essentials.Helpers;
 using OneWare.Essentials.Models;
 using OneWare.Essentials.Services;
 using OneWare.Essentials.ViewModels;
@@ -19,70 +21,60 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
 
     private readonly IProjectSettingsService _projectSettingsService;
 
+    private readonly ILogger _logger;
+
     public SettingsCollectionViewModel SettingsCollection { get; } = new("")
     {
         ShowTitle = false
     };
 
     private UniversalFpgaProjectRoot _root;
-
-    private ComboBoxSetting _toolchain;
-    private ComboBoxSetting _loader;
-    private ComboBoxSetting? _vhdlStandard;
-
-    private ListBoxSetting _includesSettings;
-    private ListBoxSetting _excludesSettings;
-
+    
     private Dictionary<TitledSetting, string> _dynamicSettingsKeys = new();
+
+    public ObservableCollection<string> SettingCategories { get; }
+    
+    private string? _selectedCategory;
+    public string? SelectedCategory
+    {
+        get => _selectedCategory;
+        set
+        {
+            SetProperty(ref _selectedCategory, value);
+            if (value != null)
+            {
+                LoadSettingsForCategory(value);
+            }
+        }
+    }
 
     public UniversalFpgaProjectSettingsEditorViewModel(UniversalFpgaProjectRoot root,
         IProjectExplorerService projectExplorerService, FpgaService fpgaService,
         IProjectSettingsService projectSettingsService, ILogger logger)
     {
         _root = root;
+        _logger = logger;
         _projectExplorerService = projectExplorerService;
         _fpgaService = fpgaService;
         _projectSettingsService = projectSettingsService;
         Title = $"{_root.Name} Settings";
+        
+        SetupMenu();
+        SettingCategories = new ObservableCollection<string>(projectSettingsService.GetProjectCategories());
+        LoadSettingsForCategory(projectSettingsService.GetDefaultProjectCategory());
+        
+    }
 
-        if (root.TopEntity != null && (root.TopEntity.Name.Contains("vhd") || root.TopEntity.Name.Contains("vhdl")))
-        {
-            var standard = _root.Properties["VHDL_Standard"];
-            var value = standard == null ? "" : standard.ToString();
-            _vhdlStandard = new ComboBoxSetting("VHDL Standard", value, ["87", "93", "93c", "00", "02", "08", "19"]);
-        }
 
-        var includes = _root.Properties["Include"]!.AsArray().Select(node => node!.ToString()).ToArray();
-        var exclude = _root.Properties["Exclude"]!.AsArray().Select(node => node!.ToString()).ToArray();
-
-        var toolchains = ContainerLocator.Container.Resolve<FpgaService>().Toolchains
-            .Select(toolchain => toolchain.Name);
-        var currentToolchain = _root.Properties["Toolchain"]!.ToString();
-        _toolchain = new ComboBoxSetting("Toolchain", currentToolchain, toolchains);
-
-        var loader = ContainerLocator.Container.Resolve<FpgaService>().Loaders.Select(loader => loader.Name);
-        var currentLoader = _root.Properties["Loader"]!.ToString();
-        _loader = new ComboBoxSetting("Loader", currentLoader, loader);
-
-        _includesSettings = new ListBoxSetting("Files to Include", includes);
-        _excludesSettings = new ListBoxSetting("Files to Exclude", exclude);
-
-        SettingsCollection.SettingModels.Add(_toolchain);
-        SettingsCollection.SettingModels.Add(_loader);
-
-        if (_vhdlStandard != null)
-        {
-            SettingsCollection.SettingModels.Add(_vhdlStandard);
-        }
-
-        SettingsCollection.SettingModels.Add(_includesSettings);
-        SettingsCollection.SettingModels.Add(_excludesSettings);
-
-        foreach (ProjectSetting setting in _projectSettingsService.GetProjectSettingsList())
+    private void LoadSettingsForCategory(string category)
+    {
+        SettingsCollection.Clear();
+        
+        foreach (ProjectSetting setting in _projectSettingsService.GetProjectSettingsList(category))
         {
             TitledSetting localCopy = setting.Setting;
 
-            if (setting.ActivationFunction(root) == false)
+            if (setting.ActivationFunction(_root) == false)
             {
                 continue;
             }
@@ -145,43 +137,96 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
 
                     default:
 
-                        logger.Error($"Unknown setting of type: {localCopy.GetType().Name}");
+                        _logger.Error($"Unknown setting of type: {localCopy.GetType().Name}");
                         continue;
                 }
             }
-
+            
             _dynamicSettingsKeys.Add(localCopy, setting.Key);
-
             SettingsCollection.SettingModels.Add(localCopy);
+            
         }
+        
+        // OnPropertyChanged();
     }
 
-    private async Task SaveAsync()
+    private void SetupMenu()
     {
-        var tcString = _toolchain.Value.ToString();
-        if (tcString != null && _fpgaService.Toolchains.FirstOrDefault(x => x.Name == tcString) is { } tc)
-            _root.Toolchain = tc;
+        // Not the right place, not the right class 
+        ComboBoxSetting? vhdlStandard = null;
 
-        var loaderString = _loader.Value.ToString();
-        if (loaderString != null && _fpgaService.Loaders.FirstOrDefault(x => x.Name == loaderString) is { } loader)
-            _root.Loader = loader;
+        if (_root.TopEntity != null && (_root.TopEntity.Name.Contains("vhd") || _root.TopEntity.Name.Contains("vhdl")))
+        {
+            var standard = _root.Properties["VHDL_Standard"];
+            var value = standard == null ? "" : standard.ToString();
+            vhdlStandard = new ComboBoxSetting("VHDL Standard", value, ["87", "93", "93c", "00", "02", "08", "19"]);
+        }
 
-        _root.SetProjectPropertyArray("Include", _includesSettings.Items.Select(item => item.ToString()).ToArray());
-        _root.SetProjectPropertyArray("Exclude", _excludesSettings.Items.Select(item => item.ToString()).ToArray());
+        var includes = _root.Properties["Include"]!.AsArray().Select(node => node!.ToString()).ToArray();
+        var exclude = _root.Properties["Exclude"]!.AsArray().Select(node => node!.ToString()).ToArray();
 
-        if (_vhdlStandard?.Value.ToString() != null)
-            _root.SetProjectProperty("VHDL_Standard", _vhdlStandard.Value.ToString()!);
+        var toolchains = ContainerLocator.Container.Resolve<FpgaService>().Toolchains
+            .Select(toolchain => toolchain.Name);
+        var currentToolchain = _root.Properties["Toolchain"]!.ToString();
+        var toolchain = new ComboBoxSetting("Toolchain", currentToolchain, toolchains);
 
+        var loaders = ContainerLocator.Container.Resolve<FpgaService>().Loaders.Select(loader => loader.Name);
+        var currentLoader = _root.Properties["Loader"]!.ToString();
+        var loader = new ComboBoxSetting("Loader", currentLoader, loaders);
+
+        var includesSettings = new ListBoxSetting("Files to Include", includes);
+        var excludesSettings = new ListBoxSetting("Files to Exclude", exclude);
+
+        _projectSettingsService.AddProjectSettingIfNotExists(
+            new ProjectSettingBuilder()
+                .WithKey("Toolchain")
+                .WithSetting(toolchain)
+                .WithDisplayOrder(100)
+                .Build()
+        );
+
+        _projectSettingsService.AddProjectSettingIfNotExists(
+            new ProjectSettingBuilder()
+                .WithKey("Loader")
+                .WithDisplayOrder(90)
+                .WithSetting(loader)
+                .Build()
+        );
+
+        if (vhdlStandard != null)
+        {
+            _projectSettingsService.AddProjectSettingIfNotExists(
+                new ProjectSettingBuilder()
+                    .WithKey("VHDL_Standard")
+                    .WithDisplayOrder(80)
+                    .WithSetting(vhdlStandard)
+                    .Build()
+            );
+        }
+
+        _projectSettingsService.AddProjectSettingIfNotExists(
+            new ProjectSettingBuilder()
+                .WithKey("Include")
+                .WithSetting(includesSettings)
+                .WithDisplayOrder(100)
+                .WithCategory("Project")
+                .Build()
+        );
+
+        _projectSettingsService.AddProjectSettingIfNotExists(
+            new ProjectSettingBuilder()
+                .WithKey("Exclude")
+                .WithSetting(excludesSettings)
+                .WithDisplayOrder(200)
+                .WithCategory("Project")
+                .Build()
+        );
+    }
+    
+    public async Task SaveAsync()
+    {
         foreach (var toSave in SettingsCollection.SettingModels)
         {
-            if (toSave == _toolchain || toSave == _loader || toSave == _includesSettings ||
-                toSave == _excludesSettings || toSave == _vhdlStandard)
-            {
-                // Hardcoded; Skip for now
-
-                continue;
-            }
-
             if (toSave is not TitledSetting)
             {
                 continue;
@@ -233,7 +278,8 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
         }
 
         await _projectExplorerService.SaveProjectAsync(_root);
-        await _projectExplorerService.ReloadAsync(_root);
+        // TODO: Why to use Reload at all?
+        // await _projectExplorerService.ReloadAsync(_root);
     }
 
     public async Task SaveAndCloseAsync(FlexibleWindow window)

--- a/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
@@ -154,9 +154,6 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
 
     private void SetupMenu()
     {
-        // Not the right place, not the right class 
-        // Maybe: UniversalFpgaProjectSystemModule.cs
-        
         var value = _root.Properties["VHDL_Standard"] == null ? "" : _root.Properties["VHDL_Standard"]!.ToString();
         ComboBoxSetting vhdlStandard = new ComboBoxSetting("VHDL Standard", value, ["87", "93", "93c", "00", "02", "08", "19"]);
         

--- a/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectSettingsEditorView.axaml
+++ b/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectSettingsEditorView.axaml
@@ -15,24 +15,51 @@
                          x:DataType="viewModels:UniversalFpgaProjectSettingsEditorViewModel"
                          Name="UniversalFpgaProjectCompileViewView">
     <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="200"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+    
         <Grid.RowDefinitions>
-            <RowDefinition Height="*" /> 
-            <RowDefinition Height="Auto" /> 
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <ScrollViewer Grid.Row="0">
+        <!-- Linke Spalte -->
+        <StackPanel Grid.Row="0" Grid.Column="0">
+            <TextBlock Text="Categories" FontWeight="Bold" Margin="5"/>
+            <ListBox
+                Margin="5"
+                ItemsSource="{Binding SettingCategories}"
+                SelectedItem="{Binding SelectedCategory}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding}" />
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </StackPanel>
+
+        <!-- Rechte Spalte -->
+        <ScrollViewer Grid.Row="0" Grid.Column="1">
             <ContentControl Padding="4" Content="{Binding SettingsCollection}" />
         </ScrollViewer>
 
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="8" Classes="WindowButtons"
+        <StackPanel Grid.Row="1" Grid.Column="1"
+                    Orientation="Horizontal"
+                    Margin="8"
+                    Classes="WindowButtons"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Bottom">
+            <Button Command="{Binding SaveAsync}"
+                    Background="{DynamicResource HighlightBrush}">
+                <TextBlock Text="Apply" Margin="5 0"/>
+            </Button>
             <Button Command="{Binding SaveAndCloseAsync}"
                     Background="{DynamicResource HighlightBrush}"
                     CommandParameter="{Binding #UniversalFpgaProjectCompileViewView}">
-                <TextBlock Text="Save and Close" Margin="5 0" />
+                <TextBlock Text="Save and Close" Margin="5 0"/>
             </Button>
         </StackPanel>
-        
     </Grid>
 </controls:FlexibleWindow>


### PR DESCRIPTION
This update introduces optional category support for ProjectSetting.
Settings can now be organized by category, enabling better structure and improved filtering in the UI or configuration tools.

If no category is provided, settings remain uncategorized for backward compatibility.


<img width="2050" height="1155" alt="image" src="https://github.com/user-attachments/assets/ffdc4b99-693e-49fa-a6c4-fb5260128a62" />
<img width="2059" height="1158" alt="image" src="https://github.com/user-attachments/assets/fd6a4b0b-5e73-47c0-91ae-2563f97d2f89" />

