### PR TITLE
[#135] Fix: OneWare Studio crashes when expanding a deleted root folder

### DIFF
--- a/src/OneWare.FolderProjectSystem/FolderProjectManager.cs
+++ b/src/OneWare.FolderProjectSystem/FolderProjectManager.cs
@@ -35,6 +35,9 @@ public class FolderProjectManager : IProjectManager
     {
         folder.Children.Clear();
         folder.Entities.Clear();
+
+        if (!Directory.Exists(folder.FullPath))
+            return;
         
         var options = new EnumerationOptions
         {


### PR DESCRIPTION
#135 

Check if the directory exists when loading a folder prevents the unhandled exception

**Notes:**
Nevertheless the deleted folder still exists. The SystemFileWatcher in ProjectWatchInstance.cs only detects changes in the root directory - not the root directory itself. An additional FileWatcher for the open folders/projects would fix this behavior.