### PR TITLE
Fix for integers having the wrong values in waveform viewer

### DIFF
--- a/src/OneWare.Vcd.Parser/VcdParser.cs
+++ b/src/OneWare.Vcd.Parser/VcdParser.cs
@@ -484,6 +484,12 @@ public static partial class VcdParser
                                     signalRegister[id].AddChange(changeTimes.Count - 1, currentLogic);
                                     break;
                                 case ParsingType.Array when signalRegister[id].ValueType == typeof(StdLogic[]):
+                                    if (currentVector.Count < signalRegister[id].BitWidth)
+                                    {
+                                        var padCount = signalRegister[id].BitWidth - currentVector.Count;
+                                        var padding = Enumerable.Repeat(StdLogic.Zero, padCount).ToList();
+                                        currentVector.InsertRange(0, padding);
+                                    }
                                     signalRegister[id].AddChange(changeTimes.Count - 1, currentVector.ToArray());
                                     break;
                                 case ParsingType.Array when signalRegister[id].ValueType == typeof(StdLogic) && currentVector.Count == 1:

--- a/tests/OneWare.Vcd.Parser.UnitTests/Assets/integer_width.vcd
+++ b/tests/OneWare.Vcd.Parser.UnitTests/Assets/integer_width.vcd
@@ -1,0 +1,17 @@
+﻿$date
+  Mon Dec  8 23:39:51 2025
+$end
+$version
+  GHDL v0
+$end
+$timescale
+  1 fs
+$end
+$scope module standard $end
+$upscope $end
+$scope module s $end
+$var integer 32 ! a $end
+$upscope $end
+$enddefinitions $end
+#0
+b1 !

--- a/tests/OneWare.Vcd.Parser.UnitTests/VcdParserTests.cs
+++ b/tests/OneWare.Vcd.Parser.UnitTests/VcdParserTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using OneWare.Vcd.Parser.Data;
@@ -42,6 +43,11 @@ public class VcdParserTests
     private static string GetTestPath5()
     {
         return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets/trace.vcd");
+    }
+    
+    private static string GetTestPath6()
+    {
+        return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets/integer_width.vcd");
     }
     
     [Fact]
@@ -153,6 +159,19 @@ public class VcdParserTests
         _output.WriteLine($"Parsing took {sw.ElapsedMilliseconds}ms");
         _output.WriteLine($"Memory occupied: {(after - before) / 1000}kB");
     }
+    
+    [Fact]
+    public void ParseTest6()
+    {
+        var result = VcdParser.ParseVcd(GetTestPath6());
+        var signal = result.GetSignal("!");
+        Assert.Equal(32, signal.BitWidth);
+        var expected = Enumerable.Repeat(StdLogic.Zero, 31)
+            .Append(StdLogic.Full)
+            .ToList();
+        Assert.Equal(expected, signal.GetValueFromOffset(0));
+    }
+
 
     [Fact]
     public void ParseTest5()


### PR DESCRIPTION
**Why**:
The integer type shows up as an std_logic array in the waveform viewer. But its always parsed with the lowest number of bits, basically guaranteeing that it ends up as a negative number. 

The GHDL simulator (and many others) always uses 32 bit signed integers, regardless of the range set in the code.

In this very basic entity generates a single signal which should have the signed/unsigned value of 1.
But instead get the waveform will show -1 when using signed, despite the integer range allowing negative numbers.
```
entity s is
end entity s;

architecture rtl of s is
    signal A : integer range -16 to 16 := 1;
begin
end architecture;
```

**How**:
I made the parsing arrays match the bit width field when there is a mismatch. So integers are now 32 bit arrays and will correctly show up in the waveform viewer. 