### PR TITLE
Add command line arguments to gtkwave call

### DIFF
--- a/src/OneWare.OssCadSuiteIntegration/OssCadSuiteIntegrationModule.cs
+++ b/src/OneWare.OssCadSuiteIntegration/OssCadSuiteIntegrationModule.cs
@@ -501,8 +501,8 @@ public class OssCadSuiteIntegrationModule : IModule
                 l.Add(new MenuItemViewModel("GtkWaveOpen")
                 {
                     Header = "Open with GTKWave",
-                    Command = new RelayCommand(() =>
-                        containerProvider.Resolve<GtkWaveService>().OpenInGtkWave(wave.FullPath))
+                    Command = new AsyncRelayCommand(async () =>
+                        await containerProvider.Resolve<GtkWaveService>().OpenInGtkWaveAsync(wave))
                 });
             if (x is [IProjectFile { Extension: ".pcf" } pcf])
             {
@@ -530,7 +530,7 @@ public class OssCadSuiteIntegrationModule : IModule
 
         containerProvider.Resolve<IDockService>().RegisterFileOpenOverwrite(x =>
         {
-            containerProvider.Resolve<GtkWaveService>().OpenInGtkWave(x.FullPath);
+            containerProvider.Resolve<GtkWaveService>().OpenInGtkWaveAsync(x).RunSynchronously();
             return true;
         }, ".ghw", ".fst");
     }

--- a/src/OneWare.OssCadSuiteIntegration/Tools/GtkWaveService.cs
+++ b/src/OneWare.OssCadSuiteIntegration/Tools/GtkWaveService.cs
@@ -1,12 +1,24 @@
 ﻿using OneWare.Essentials.Enums;
+using OneWare.Essentials.Models;
 using OneWare.Essentials.Services;
+using OneWare.UniversalFpgaProjectSystem.Context;
 
 namespace OneWare.OssCadSuiteIntegration.Tools;
 
 public class GtkWaveService(IChildProcessService childProcessService)
 {
-    public void OpenInGtkWave(string path)
+    private static readonly string[] GtkProperties = ["GtkwSaveFile", "GtkwWaveArgs"];
+
+    public async Task OpenInGtkWaveAsync(IFile file)
     {
-        childProcessService.StartWeakProcess("gtkwave", [Path.GetFileName(path)], Path.GetDirectoryName(path) ?? "");
+        var context = await TestBenchContextManager.LoadContextAsync(file);
+        List<string> args = [Path.GetFileName(file.FullPath)];
+
+        foreach (var property in GtkProperties)
+            if (context.Properties.TryGetPropertyValue(property, out var jsonNode) && jsonNode != null && jsonNode.GetValueKind() == System.Text.Json.JsonValueKind.String)            
+                args.Add(jsonNode.GetValue<string>());
+
+        // save file has to be provided as second argument without "--save"
+        childProcessService.StartWeakProcess("gtkwave", args, Path.GetDirectoryName(file.FullPath) ?? "");
     }
 }


### PR DESCRIPTION
Using https://github.com/one-ware/OneWare.GhdlExtension/pull/23 one can supply arguments to GTKWave through the TestBenchContextManager.