### PR TITLE
Fix/provide treedatagrid in essentials

### DIFF
--- a/OneWare.slnx
+++ b/OneWare.slnx
@@ -18,6 +18,7 @@
     <File Path="build/props/Avalonia.Browser.props" />
     <File Path="build/props/Avalonia.Controls.ColorPicker.props" />
     <File Path="build/props/Avalonia.Controls.DataGrid.props" />
+    <File Path="build/props/Avalonia.Controls.TreeDataGrid.props" />
     <File Path="build/props/Avalonia.Desktop.props" />
     <File Path="build/props/Avalonia.Diagnostics.props" />
     <File Path="build/props/Avalonia.Fonts.Inter.props" />

--- a/build/props/Avalonia.Controls.TreeDataGrid.props
+++ b/build/props/Avalonia.Controls.TreeDataGrid.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <ItemGroup>
+        <PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="11.1.1"/>
+    </ItemGroup>
+</Project>

--- a/src/OneWare.Essentials/OneWare.Essentials.csproj
+++ b/src/OneWare.Essentials/OneWare.Essentials.csproj
@@ -9,6 +9,7 @@
     <Import Project="..\..\build\props\ReactiveUI.Avalonia.props"/>
     <Import Project="..\..\build\props\Avalonia.Controls.ColorPicker.props"/>
     <Import Project="..\..\build\props\Avalonia.Controls.DataGrid.props"/>
+    <Import Project="..\..\build\props\Avalonia.Controls.TreeDataGrid.props"/>
     <Import Project="..\..\build\props\PanAndZoom.props"/>
     <Import Project="..\..\build\props\AvaloniaEdit.props"/>
     <Import Project="..\..\build\props\AvaloniaEdit.TextMate.props"/>

--- a/src/OneWare.LibraryExplorer/OneWare.LibraryExplorer.csproj
+++ b/src/OneWare.LibraryExplorer/OneWare.LibraryExplorer.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\build\props\Base.props"/>
     <Import Project="..\..\build\props\OneWare.Module.props"/>
+    <Import Project="..\..\build\props\Avalonia.Controls.TreeDataGrid.props"/>
 
     <ItemGroup>
         <ProjectReference Include="..\OneWare.Essentials\OneWare.Essentials.csproj"/>
@@ -13,9 +14,5 @@
             <DependentUpon>ProjectExplorerView.axaml</DependentUpon>
             <SubType>Code</SubType>
         </Compile>
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="11.1.1"/>
     </ItemGroup>
 </Project>

--- a/src/OneWare.ProjectExplorer/OneWare.ProjectExplorer.csproj
+++ b/src/OneWare.ProjectExplorer/OneWare.ProjectExplorer.csproj
@@ -1,12 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\build\props\Base.props"/>
     <Import Project="..\..\build\props\OneWare.Module.props"/>
+    <Import Project="..\..\build\props\Avalonia.Controls.TreeDataGrid.props"/>
 
     <ItemGroup>
         <ProjectReference Include="..\OneWare.Essentials\OneWare.Essentials.csproj"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="11.1.1"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR resolves #177 by centralising the versioning of the TreeDataGrid dependency and providing it as part of `OneWare.Essentials`. 