### PR TITLE
Validation for project-specific settings

### DIFF
--- a/src/OneWare.Essentials/Models/Setting.cs
+++ b/src/OneWare.Essentials/Models/Setting.cs
@@ -117,7 +117,10 @@ public class CheckBoxSetting : TitledSetting
 
     public override TitledSetting Clone()
     {
-        return new CheckBoxSetting(Title, (bool)DefaultValue);
+        return new CheckBoxSetting(Title, (bool)DefaultValue)
+        {
+	        Validator = Validator
+        };
     }
 }
 
@@ -138,7 +141,10 @@ public class TextBoxSetting : TitledSetting
 
     public override TitledSetting Clone()
     {
-        return new TextBoxSetting(Title, DefaultValue, Watermark);
+        return new TextBoxSetting(Title, DefaultValue, Watermark)
+        {
+	        Validator = Validator
+        };
     }
 }
 
@@ -165,7 +171,10 @@ public class ComboBoxSetting : TitledSetting
 
     public override TitledSetting Clone()
     {
-        return new ComboBoxSetting(Title, DefaultValue, Options);
+        return new ComboBoxSetting(Title, DefaultValue, Options)
+        {
+	        Validator = Validator
+        };
     }
 }
 
@@ -174,7 +183,10 @@ public class AdvancedComboBoxSearchSetting(string title, object defaultValue, Ad
 {
     public override TitledSetting Clone()
     {
-        return new AdvancedComboBoxSearchSetting(Title, DefaultValue, Options);
+        return new AdvancedComboBoxSearchSetting(Title, DefaultValue, Options)
+        {
+	        Validator = Validator
+        };
     }
 }
 
@@ -205,7 +217,10 @@ public class AdvancedComboBoxSetting : TitledSetting
 
     public override TitledSetting Clone()
     {
-        return new AdvancedComboBoxSetting(Title, DefaultValue, Options);
+        return new AdvancedComboBoxSetting(Title, DefaultValue, Options)
+        {
+	        Validator = Validator
+        };
     }
 }
 
@@ -244,7 +259,10 @@ public class ListBoxSetting : TitledSetting
 
     public override TitledSetting Clone()
     {
-        return new ListBoxSetting(Title, ((ObservableCollection<string>)DefaultValue).ToArray());
+        return new ListBoxSetting(Title, ((ObservableCollection<string>)DefaultValue).ToArray())
+        {
+	        Validator = Validator
+        };
     }
 }
 
@@ -286,7 +304,10 @@ public class SliderSetting : TitledSetting
 
     public override TitledSetting Clone()
     {
-        return new SliderSetting(Title, (double)DefaultValue, Min, Max, Step);
+        return new SliderSetting(Title, (double)DefaultValue, Min, Max, Step)
+        {
+	        Validator = Validator
+        };
     }
 }
 
@@ -362,7 +383,10 @@ public class ColorSetting : TitledSetting
 
     public override TitledSetting Clone()
     {
-        return new ColorSetting(Title, (Color)DefaultValue);
+        return new ColorSetting(Title, (Color)DefaultValue)
+        {
+	        Validator = Validator
+        };
     }
 }
 

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingsService.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/ProjectSettingsService.cs
@@ -43,7 +43,13 @@ public class ProjectSettingsService : IProjectSettingsService
     /// <inheritdoc />
     public List<ProjectSetting> GetProjectSettingsList(string category)
     {
-        return ProjectSettingsByCategory[category];
+	    List<ProjectSetting> ret = new();
+
+	    foreach (var projectSetting in ProjectSettingsByCategory[category])
+		    ret.Add(new ProjectSetting(projectSetting.Key, projectSetting.Setting.Clone(),
+			    projectSetting.ActivationFunction));
+
+	    return ret;
     }
 
     public string GetDefaultProjectCategory()

--- a/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectSettingsEditorViewModel.cs
@@ -81,53 +81,80 @@ public class UniversalFpgaProjectSettingsEditorViewModel : FlexibleWindowViewMod
                 {
                     case "CheckBoxSetting":
                         localCopy = new CheckBoxSetting(localCopy.Title,
-                            _root.Properties[setting.Key]!.ToString() == "True" ? true : false);
+                            _root.Properties[setting.Key]!.ToString() == "True" ? true : false)
+                        {
+	                        Validator = localCopy.Validator
+                        };
                         break;
 
                     case "TextBoxSetting":
                         localCopy = new TextBoxSetting(localCopy.Title, _root.Properties[setting.Key]!.ToString(),
-                            ((TextBoxSetting)localCopy).Watermark);
+                            ((TextBoxSetting)localCopy).Watermark)
+                        {
+	                        Validator = localCopy.Validator
+                        };
                         break;
 
                     case "ComboBoxSetting":
                         localCopy = new ComboBoxSetting(localCopy.Title, _root.Properties[setting.Key]!.ToString(),
-                            ((ComboBoxSetting)localCopy).Options);
+                            ((ComboBoxSetting)localCopy).Options)
+                        {
+	                        Validator = localCopy.Validator
+                        };
                         break;
 
                     case "ListBoxSetting":
                         localCopy = new ListBoxSetting(localCopy.Title,
-                            _root.Properties[setting.Key]!.AsArray().Select(node => node!.ToString()).ToArray());
+                            _root.Properties[setting.Key]!.AsArray().Select(node => node!.ToString()).ToArray())
+                        {
+	                        Validator = localCopy.Validator
+                        };
                         break;
 
                     case "ComboBoxSearchSetting":
                         localCopy = new ComboBoxSearchSetting(localCopy.Title,
                             _root.Properties[setting.Key]!.AsArray().Select(node => node!.ToString()).ToArray(),
-                            ((ComboBoxSearchSetting)localCopy).Options);
+                            ((ComboBoxSearchSetting)localCopy).Options)
+                        {
+	                        Validator = localCopy.Validator
+                        };
                         break;
 
                     case "SliderSetting":
                         localCopy = new SliderSetting(localCopy.Title,
                             double.Parse(_root.Properties[setting.Key]!.ToString(), CultureInfo.InvariantCulture),
                             ((SliderSetting)localCopy).Min,
-                            ((SliderSetting)localCopy).Max, ((SliderSetting)localCopy).Step);
+                            ((SliderSetting)localCopy).Max, ((SliderSetting)localCopy).Step)
+                        {
+	                        Validator = localCopy.Validator
+                        };
                         break;
 
                     case "FolderPathSetting":
                         localCopy = new FolderPathSetting(localCopy.Title,
                             _root.Properties[setting.Key]!.ToString(), ((FolderPathSetting)localCopy).Watermark,
-                            ((FolderPathSetting)localCopy).StartDirectory, ((FolderPathSetting)localCopy).CheckPath);
+                            ((FolderPathSetting)localCopy).StartDirectory, ((FolderPathSetting)localCopy).CheckPath)
+                        {
+	                        Validator = localCopy.Validator
+                        };
                         break;
 
                     case "FilePathSetting":
                         localCopy = new FilePathSetting(localCopy.Title,
                             _root.Properties[setting.Key]!.ToString(),
                             ((FilePathSetting)localCopy).Watermark, ((FilePathSetting)localCopy).StartDirectory,
-                            ((FilePathSetting)localCopy).CheckPath);
+                            ((FilePathSetting)localCopy).CheckPath)
+                        {
+	                        Validator = localCopy.Validator
+                        };
                         break;
 
                     case "ColorSetting":
                         Color.TryParse(_root.Properties[setting.Key]!.ToString(), out var color);
-                        localCopy = new ColorSetting(localCopy.Title, color);
+                        localCopy = new ColorSetting(localCopy.Title, color)
+                        {
+	                        Validator = localCopy.Validator
+                        };
                         break;
 
                     default:


### PR DESCRIPTION
This PR implements two changes:
1. It replaces the existing validation approach of using the `ISettingValidation` interface with validation based on Func<>. This aims to prevent stateful validation from occuring, thereby eliminating validation issues between project-specific settings
2. It adds the new validation function to project-specific settings, expanding validation coverage from global settings to all settings