### PR TITLE
Rename fpga property

### DIFF
--- a/docs/PluginDevelopment.md
+++ b/docs/PluginDevelopment.md
@@ -393,7 +393,7 @@ model for FPGA workflows. It is designed to be extended by plugins.
   - `topEntity`: relative path to the top-level HDL file.
   - `toolchain`: toolchain ID to run on compile.
   - `loader`: loader ID to use for programming.
-  - `fpga`: selected FPGA package name.
+  - `board`: selected hardware board (evaluation board) name. The legacy key `fpga` is automatically migrated to `board` on load.
   - `testBenches`: list of relative paths flagged as test benches.
   - `compileExcluded`: list of relative paths excluded from compile.
 

--- a/src/OneWare.Essentials/Models/UniversalProjectProperties.cs
+++ b/src/OneWare.Essentials/Models/UniversalProjectProperties.cs
@@ -29,6 +29,12 @@ public class UniversalProjectProperties : IEnumerable<KeyValuePair<string, JsonN
 {
     private JsonObject _data;
 
+    /// <summary>
+    /// Read-only aliases: when a key is not found, look up its alias target instead.
+    /// Registered via <see cref="RegisterAlias"/>.
+    /// </summary>
+    private readonly Dictionary<string, string> _aliases = new(StringComparer.OrdinalIgnoreCase);
+
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
         WriteIndented = true,
@@ -76,6 +82,16 @@ public class UniversalProjectProperties : IEnumerable<KeyValuePair<string, JsonN
     public bool Remove(string key)
     {
         return RemoveNodeInternal(key, out _);
+    }
+
+    /// <summary>
+    /// Registers a read-only alias so that looking up <paramref name="alias"/> transparently
+    /// returns the value stored under <paramref name="canonical"/> when the alias key itself is
+    /// absent from the project file. Useful for backwards-compatibility with old key names.
+    /// </summary>
+    public void RegisterAlias(string alias, string canonical)
+    {
+        _aliases[alias] = canonical;
     }
 
     public async Task<bool> LoadAsync(string path, IEnumerable<ProjectPropertyMigration>? migrations = null)
@@ -289,7 +305,16 @@ public class UniversalProjectProperties : IEnumerable<KeyValuePair<string, JsonN
                 return null;
 
             if (!TryGetNode(obj, segment, out var next))
+            {
+                // Fall back to a registered alias when the segment itself is absent
+                if (_aliases.TryGetValue(segment, out var aliasTarget) &&
+                    TryGetNode(obj, aliasTarget, out next))
+                {
+                    current = next;
+                    continue;
+                }
                 return null;
+            }
 
             current = next;
         }

--- a/src/OneWare.OssCadSuiteIntegration/Loaders/OpenFpgaLoader.cs
+++ b/src/OneWare.OssCadSuiteIntegration/Loaders/OpenFpgaLoader.cs
@@ -26,9 +26,9 @@ public class OpenFpgaLoader(ISettingsService settingsService, ILogger logger, IO
 
     public async Task DownloadAsync(UniversalFpgaProjectRoot project)
     {
-        var fpga = project.Properties.GetString("Fpga") ?? "unknown";
+        var boardName = project.Board ?? "unknown";
         var longTerm = settingsService.GetSettingValue<bool>("UniversalFpgaProjectSystem_LongTermProgramming");
-        var properties = FpgaSettingsParser.LoadSettings(project, fpga);
+        var properties = FpgaSettingsParser.LoadSettings(project, boardName);
 
         var board = properties.GetValueOrDefault("openFpgaLoaderBoard");
         var cable = properties.GetValueOrDefault("OpenFpgaLoader_Cable");

--- a/src/OneWare.OssCadSuiteIntegration/OssCadSuiteIntegrationModule.cs
+++ b/src/OneWare.OssCadSuiteIntegration/OssCadSuiteIntegrationModule.cs
@@ -93,7 +93,7 @@ public class OssCadSuiteIntegrationModule : OneWareModuleBase
             {
                 if (x is not UniversalFpgaProjectRoot { Toolchain: YosysToolchain.ToolChainId } root) return null;
 
-                var name = root.Properties["Fpga"]?.ToString();
+                var name = root.Board;
                 var fpgaPackage = fpgaService.FpgaPackages.FirstOrDefault(obj => obj.Name == name);
                 var fpga = fpgaPackage?.LoadFpga();
 
@@ -144,7 +144,7 @@ public class OssCadSuiteIntegrationModule : OneWareModuleBase
                                 if (projectExplorerService
                                         .ActiveProject is UniversalFpgaProjectRoot fpgaProjectRoot)
                                 {
-                                    var selectedFpga = root.Properties["Fpga"]?.ToString();
+                                    var selectedFpga = root.Board;
                                     var selectedFpgaPackage =
                                         fpgaService.FpgaPackages.FirstOrDefault(obj => obj.Name == selectedFpga);
 

--- a/src/OneWare.UniversalFpgaProjectSystem/Models/UniversalFpgaProjectRoot.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Models/UniversalFpgaProjectRoot.cs
@@ -19,6 +19,10 @@ public class UniversalFpgaProjectRoot : UniversalProjectRoot
     
     public UniversalFpgaProjectRoot(string projectFilePath) : base(projectFilePath)
     {
+        // "fpga" was the legacy key for the board; alias it so old plugins that call
+        // Properties.GetString("fpga") continue to receive the migrated "board" value.
+        Properties.RegisterAlias("fpga", "board");
+
         RegisterProjectEntryModification(x =>
         {
             if (x is IProjectFile file && IsTestBench(file.RelativePath))
@@ -74,6 +78,16 @@ public class UniversalFpgaProjectRoot : UniversalProjectRoot
     {
         get => Properties.GetString("loader");
         set => Properties.SetString("loader", value);
+    }
+
+    /// <summary>
+    /// The selected hardware board (evaluation board) for this project.
+    /// Stored as <c>board</c> in the project file; old files using <c>fpga</c> are migrated automatically.
+    /// </summary>
+    public string? Board
+    {
+        get => Properties.GetString("board");
+        set => Properties.SetString("board", value);
     }
 
     public bool IsTestBench(string relativePath)

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/FpgaService.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/FpgaService.cs
@@ -252,7 +252,7 @@ public class FpgaService
 
             if (fpgaModel == null)
             {
-                var name = project.Properties.GetString("fpga");
+                var name = project.Board;
                 var fpgaPackage = FpgaPackages.FirstOrDefault(obj => obj.Name == name);
                 if (fpgaPackage == null)
                 {

--- a/src/OneWare.UniversalFpgaProjectSystem/UniversalFpgaProjectSystemModule.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/UniversalFpgaProjectSystemModule.cs
@@ -123,6 +123,8 @@ public class UniversalFpgaProjectSystemModule : OneWareModuleBase
         fpgaService.RegisterProjectPropertyMigration("VHDL_Standard", "vhdlStandard");
         fpgaService.RegisterProjectPropertyMigration("Toolchain", "toolchain", NormalizeToolchain);
         fpgaService.RegisterProjectPropertyMigration("Loader", "loader", NormalizeLoader);
+        fpgaService.RegisterProjectPropertyMigration("fpga", "board"); // legacy key renamed to "board"
+        fpgaService.RegisterProjectPropertyMigration("Fpga", "board"); // PascalCase variant also migrated
     }
 
     private static JsonNode? NormalizeToolchain(JsonNode? node)

--- a/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectPinPlannerViewModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectPinPlannerViewModel.cs
@@ -145,7 +145,7 @@ public class UniversalFpgaProjectPinPlannerViewModel : FlexibleWindowViewModelBa
             _nodes = nodesEnumerable.ToArray();
             RefreshHardware();
 
-            SelectedFpgaPackage = FpgaPackages.FirstOrDefault(x => x.Name == Project.Properties.GetString("fpga")) ??
+            SelectedFpgaPackage = FpgaPackages.FirstOrDefault(x => x.Name == Project.Board) ??
                                   FpgaPackages.FirstOrDefault();
 
             IsDirty = false;
@@ -237,7 +237,7 @@ public class UniversalFpgaProjectPinPlannerViewModel : FlexibleWindowViewModelBa
         if (SelectedFpgaModel != null)
         {
             FpgaSettingsParser.WriteDefaultSettingsIfEmpty(Project, SelectedFpgaModel.Fpga);
-            Project.Properties.SetString("fpga", SelectedFpgaModel.Fpga.Name);
+            Project.Board = SelectedFpgaModel.Fpga.Name;
             Toolchain?.SaveConnections(Project, SelectedFpgaModel);
             _ = _projectExplorerService.SaveProjectAsync(Project);
 


### PR DESCRIPTION
Backwards compatible way to rename the "fpga" property to "board", since it makes more sense here