### PR TITLE
Fix Yosys Issues

### DIFF
--- a/src/OneWare.OssCadSuiteIntegration/ViewModels/YosysCompileSettingsViewModel.cs
+++ b/src/OneWare.OssCadSuiteIntegration/ViewModels/YosysCompileSettingsViewModel.cs
@@ -83,7 +83,7 @@ public class YosysCompileSettingsViewModel : FlexibleWindowViewModelBase
         };
 
         _yosysQuietFlagSetting = new CheckBoxSetting("Yosys Verbose", 
-            Boolean.Parse(defaultProperties.GetValueOrDefault("yosysQuietFlag") ?? "true"));
+            !Boolean.Parse(defaultProperties.GetValueOrDefault("yosysQuietFlag") ?? "true"));
 
         _nextPnrToolSetting = new ComboBoxSetting("NextPnr Tool",
             defaultProperties.GetValueOrDefault("yosysToolchainNextPnrTool") ?? "", [
@@ -169,8 +169,9 @@ public class YosysCompileSettingsViewModel : FlexibleWindowViewModelBase
             _yosysFlagSetting.Value = yFlags;
         if (_settings.TryGetValue("yosysToolchainCommand", out var yCommand))
             _yosysCommandSetting.Value = yCommand;
-        if (_settings.TryGetValue("yosysQuietFlag", out var yQuiet))
-            _yosysQuietFlagSetting.Value = yQuiet;
+        if (_settings.TryGetValue("yosysQuietFlag", out var yQuiet)
+            && Boolean.TryParse(yQuiet, out var quiet))
+            _yosysQuietFlagSetting.Value = !quiet;
 
         if (_settings.TryGetValue("yosysToolchainNextPnrTool", out var nTool))
             _nextPnrToolSetting.Value = nTool;
@@ -207,7 +208,7 @@ public class YosysCompileSettingsViewModel : FlexibleWindowViewModelBase
         _settings["yosysToolchainCommand"] = _yosysCommandSetting.Value.ToString()!;
         _settings["yosysToolchainOutputType"] = _nextPnrToolOutputTypeSetting.Value.ToString()!;
         _settings["packToolOutputFormat"] = _packOutputTypeSetting.Value.ToString()!;
-        _settings["yosysQuietFlag"] = _yosysQuietFlagSetting.Value.ToString()!;
+        _settings["yosysQuietFlag"] = (!(bool)_yosysQuietFlagSetting.Value).ToString();
 
         FpgaSettingsParser.SaveSettings(_fpgaProjectRoot, _selectedFpga.Name, _settings);
 

--- a/src/OneWare.OssCadSuiteIntegration/Yosys/YosysService.cs
+++ b/src/OneWare.OssCadSuiteIntegration/Yosys/YosysService.cs
@@ -98,6 +98,17 @@ public class YosysService(
 
                     outputService.WriteLine(x);
                     return true;
+                })
+                .WithErrorHandler(x =>
+                {
+                    if (x.StartsWith("Error:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        logger.Error(x);
+                        return false;
+                    }
+
+                    outputService.WriteLine(x);
+                    return true;
                 });
 
 


### PR DESCRIPTION
This pull request updates how the "Yosys Verbose" setting is handled in the `YosysCompileSettingsViewModel`, ensuring that the UI checkbox accurately reflects the intended meaning of the `yosysQuietFlag` property (i.e., checking "Verbose" means quiet mode is off). Additionally, it improves error handling in the Yosys synthesis process by logging error messages more clearly.

**Yosys Verbose/Quiet Flag Handling:**

* Inverts the logic for the `yosysQuietFlag` property when initializing and saving the "Yosys Verbose" checkbox, so that the UI reflects the user's intent correctly (checked means verbose, unchecked means quiet) [[1]](diffhunk://#diff-250b21fd0dfc8d81da0bdc97c3636f3725c8e9deed2fa9d3e8c59f62b7e8b894L86-R86) [[2]](diffhunk://#diff-250b21fd0dfc8d81da0bdc97c3636f3725c8e9deed2fa9d3e8c59f62b7e8b894L172-R174) [[3]](diffhunk://#diff-250b21fd0dfc8d81da0bdc97c3636f3725c8e9deed2fa9d3e8c59f62b7e8b894L210-R211).

**Error Handling Improvements:**

* Adds explicit logging for error messages that start with "Error:" during the Yosys synthesis process, making it easier to identify and debug errors.