### PR TITLE
Add SECURITY.md and supply-chain automation (CRA)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Dependabot keeps dependencies patched, supporting CRA Annex I Part II
+# (identify & address vulnerabilities without undue delay).
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      avalonia:
+        patterns:
+          - "Avalonia*"
+      microsoft:
+        patterns:
+          - "Microsoft.*"
+          - "System.*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,0 +1,47 @@
+# Fails CI when OneWare Studio depends on a NuGet package with a known
+# vulnerability. Supports the EU Cyber Resilience Act (Regulation (EU) 2024/2847),
+# Annex I Part I(1) and Part II. See compliance/cra/ for details.
+
+name: Dependency Vulnerability Scan
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore workloads
+        run: dotnet workload restore studio/OneWare.Studio.Desktop/OneWare.Studio.Desktop.csproj
+
+      - name: Restore
+        run: dotnet restore studio/OneWare.Studio.Desktop/OneWare.Studio.Desktop.csproj
+
+      - name: Scan for vulnerable packages
+        run: |
+          set -euo pipefail
+          dotnet list studio/OneWare.Studio.Desktop/OneWare.Studio.Desktop.csproj \
+            package --vulnerable --include-transitive 2>&1 | tee vuln.txt
+          if grep -E -i '(Critical|High|Moderate|Low)[[:space:]]' vuln.txt; then
+            echo "::error::Known-vulnerable NuGet packages detected"
+            exit 1
+          fi
+          echo "No known-vulnerable packages found."

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,49 @@
+# Generates a CycloneDX Software Bill of Materials (SBOM) for OneWare Studio.
+# Supports the EU Cyber Resilience Act (Regulation (EU) 2024/2847), Annex I
+# Part II. See compliance/cra/ for the surrounding documentation.
+
+name: SBOM
+
+on:
+  push:
+    branches: [ "main" ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore workloads
+        run: dotnet workload restore studio/OneWare.Studio.Desktop/OneWare.Studio.Desktop.csproj
+
+      - name: Install CycloneDX tool
+        run: dotnet tool install --global CycloneDX
+
+      - name: Generate SBOM (CycloneDX)
+        run: |
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          dotnet CycloneDX studio/OneWare.Studio.Desktop/OneWare.Studio.Desktop.csproj \
+            --output sbom \
+            --filename sbom-oneware-studio.json \
+            --json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-oneware-studio
+          path: sbom/sbom-oneware-studio.json
+          retention-days: 90

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,6 +1,8 @@
 # Generates a CycloneDX Software Bill of Materials (SBOM) for OneWare Studio.
 # Supports the EU Cyber Resilience Act (Regulation (EU) 2024/2847), Annex I
-# Part II. See compliance/cra/ for the surrounding documentation.
+# Part II. On a published release the SBOM is attached to the GitHub Release and
+# archived for long-term (10-year) retention in the private one-ware/Compliance
+# repository, where the internal CRA documentation is maintained.
 
 name: SBOM
 
@@ -17,6 +19,8 @@ permissions:
 jobs:
   sbom:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # attach SBOM assets to the release
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,9 +45,55 @@ jobs:
             --filename sbom-oneware-studio.json \
             --json
 
-      - name: Upload SBOM artifact
+      - name: Upload SBOM artifact (CI convenience, short-lived)
         uses: actions/upload-artifact@v4
         with:
           name: sbom-oneware-studio
           path: sbom/sbom-oneware-studio.json
           retention-days: 90
+
+      - name: Attach SBOM to the GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: sbom/sbom-oneware-studio.json
+
+  # On release, archive the SBOM into the private one-ware/Compliance repo for
+  # long-term (10-year) retention and per-version indexing. Requires a PAT with
+  # write access to one-ware/Compliance in the secret COMPLIANCE_SBOM_TOKEN.
+  # No-ops if the secret is not configured.
+  archive:
+    needs: sbom
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    env:
+      TOKEN: ${{ secrets.COMPLIANCE_SBOM_TOKEN }}
+      PRODUCT: oneware-studio
+      VERSION: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Download SBOMs from this run
+        if: env.TOKEN != ''
+        uses: actions/download-artifact@v4
+        with:
+          path: sboms
+
+      - name: Checkout Compliance repo
+        if: env.TOKEN != ''
+        uses: actions/checkout@v4
+        with:
+          repository: one-ware/Compliance
+          token: ${{ env.TOKEN }}
+          path: compliance
+
+      - name: Archive SBOM and commit
+        if: env.TOKEN != ''
+        run: |
+          dest="compliance/products/${PRODUCT}/sbom/${VERSION}"
+          mkdir -p "$dest"
+          find sboms -name '*.json' -exec cp {} "$dest/" \;
+          cd compliance
+          git config user.name "oneware-sbom-bot"
+          git config user.email "info@one-ware.com"
+          git add -A
+          git diff --cached --quiet || git commit -m "sbom(${PRODUCT}): ${VERSION}"
+          git push

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,9 +5,10 @@ our **Coordinated Vulnerability Disclosure (CVD) policy** and public point of
 contact for reporting security vulnerabilities, aligned with the EU Cyber
 Resilience Act (Regulation (EU) 2024/2847), Annex I Part II.
 
-OneWare Studio is free and open-source software (Apache-2.0). See
-[compliance/cra/](compliance/cra/README.md) for the full CRA compliance
-documentation, including the open-source classification analysis.
+OneWare Studio is free and open-source software (Apache-2.0). The full CRA
+compliance documentation (classification, gap analysis, technical file) is
+maintained internally by ONE WARE GmbH and provided to market-surveillance
+authorities on request.
 
 ## Reporting a Vulnerability
 
@@ -58,12 +59,13 @@ Out of scope:
 ## Supported Versions & Security Updates
 
 Security updates are provided free of charge for supported versions throughout
-the product support period. See
-[compliance/cra/support-period.md](compliance/cra/support-period.md).
+the product support period. ONE WARE GmbH commits to a minimum **5-year**
+security-update support period for OneWare Studio from each release.
 
 ## Regulatory Reporting
 
 For **actively exploited vulnerabilities** and **severe incidents**, ONE WARE
 GmbH notifies ENISA and the German national CSIRT (BSI/CERT-Bund) within the
 CRA timelines (early warning within 24 hours, full notification within 72 hours).
-See [compliance/cra/vulnerability-handling-policy.md](compliance/cra/vulnerability-handling-policy.md).
+The internal vulnerability-handling procedure that governs this process is
+maintained by ONE WARE GmbH.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,69 @@
+# Security Policy
+
+ONE WARE GmbH takes the security of OneWare Studio seriously. This document is
+our **Coordinated Vulnerability Disclosure (CVD) policy** and public point of
+contact for reporting security vulnerabilities, aligned with the EU Cyber
+Resilience Act (Regulation (EU) 2024/2847), Annex I Part II.
+
+OneWare Studio is free and open-source software (Apache-2.0). See
+[compliance/cra/](compliance/cra/README.md) for the full CRA compliance
+documentation, including the open-source classification analysis.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Report them privately by email:
+
+- **Email:** `info@one-ware.com` (please put *"Security"* in the subject line)
+
+Please include, where possible:
+
+- The affected component and version / commit / installed package (Snap, Flathub,
+  WinGet, or direct download).
+- Your operating system and how OneWare Studio was installed.
+- Step-by-step reproduction instructions or a proof of concept.
+- The potential impact.
+- Any suggested remediation.
+
+## Our Commitment (Response Targets)
+
+| Stage | Target |
+|---|---|
+| Acknowledge receipt | within **3 business days** |
+| Initial assessment & severity triage (CVSS) | within **10 business days** |
+| Status updates during remediation | at least **every 14 days** |
+| Fix or documented mitigation (by severity) | Critical 7 days · High 30 days · Medium 90 days |
+
+We follow **coordinated disclosure** and will credit reporters who wish to be
+acknowledged.
+
+## Scope
+
+In scope:
+
+- OneWare Studio desktop application (Windows, macOS, Linux) and the web build.
+- Source code in this repository and first-party OneWare extensions maintained here.
+
+Out of scope:
+
+- Third-party extensions and integrated tools (GHDL, IVerilog, etc.) — report to
+  the respective project.
+- The closed-source OneWare.AI extension and OneWare Cloud — see their own
+  security policies / `info@one-ware.com`.
+- Social engineering, physical attacks, or automated-scanner output without a
+  demonstrated, exploitable impact.
+
+## Supported Versions & Security Updates
+
+Security updates are provided free of charge for supported versions throughout
+the product support period. See
+[compliance/cra/support-period.md](compliance/cra/support-period.md).
+
+## Regulatory Reporting
+
+For **actively exploited vulnerabilities** and **severe incidents**, ONE WARE
+GmbH notifies ENISA and the German national CSIRT (BSI/CERT-Bund) within the
+CRA timelines (early warning within 24 hours, full notification within 72 hours).
+See [compliance/cra/vulnerability-handling-policy.md](compliance/cra/vulnerability-handling-policy.md).


### PR DESCRIPTION
Adds the public, CRA-supporting artifacts for OneWare Studio:

- **`SECURITY.md`** — Coordinated Vulnerability Disclosure (CVD) policy and public point of contact, aligned with CRA Annex I Part II / ISO 29147.
- **`.github/dependabot.yml`** — automated dependency-update PRs.
- **`.github/workflows/sbom.yml`** — CycloneDX SBOM generation.
- **`.github/workflows/dependency-scan.yml`** — fails CI on known-vulnerable NuGet packages.

The full internal CRA documentation (classification, Annex I gap analysis, Annex VII technical file, vulnerability-handling policy, support period, Declaration of Conformity) is maintained privately in **`one-ware/Compliance`** and is provided to authorities on request — it is intentionally not published here.
