### PR TITLE
Fix dock layout crashes and unreliable tool-window reopen

### DIFF
--- a/OneWare.slnx
+++ b/OneWare.slnx
@@ -126,6 +126,7 @@
     <Project Path="studio/OneWare.Studio/OneWare.Studio.csproj" />
   </Folder>
   <Folder Name="/Tests/">
+    <Project Path="tests/OneWare.Dock.HeadlessTests/OneWare.Dock.HeadlessTests.csproj" />
     <Project Path="tests/OneWare.Essentials.UnitTests/OneWare.Essentials.UnitTests.csproj" />
     <Project Path="tests/OneWare.PackageManager.UnitTests/OneWare.PackageManager.UnitTests.csproj" />
     <Project Path="tests/OneWare.Studio.Desktop.UnitTests/OneWare.Studio.Desktop.UnitTests.csproj" />

--- a/src/OneWare.Core/Services/MainDockService.cs
+++ b/src/OneWare.Core/Services/MainDockService.cs
@@ -130,6 +130,62 @@ public class MainDockService : Factory, IMainDockService
         base.FloatDockable(dockable);
     }
 
+    public override void CloseDockable(IDockable dockable)
+    {
+        try
+        {
+            base.CloseDockable(dockable);
+        }
+        catch (Exception e)
+        {
+            // Dock's collapse logic throws a NullReferenceException when the last
+            // dockable of a floating window is closed (issue #257). Recover instead of
+            // letting the exception bubble up and crash the whole application.
+            ContainerLocator.Container.Resolve<ILogger>()
+                ?.Warning("Error while closing dockable, recovering floating window state", e);
+
+            SafeRemoveDockable(dockable);
+            CloseEmptyFloatingWindows();
+        }
+    }
+
+    private void SafeRemoveDockable(IDockable dockable)
+    {
+        if (dockable.Owner is IDock { VisibleDockables: { } dockables } &&
+            dockables.Contains(dockable))
+        {
+            dockables.Remove(dockable);
+            OnDockableClosed(dockable);
+        }
+    }
+
+    private void CloseEmptyFloatingWindows()
+    {
+        if (Layout?.Windows == null) return;
+
+        foreach (var window in Layout.Windows.ToList())
+        {
+            if (window.Layout is { } layout && HasContentDockable(layout)) continue;
+
+            try
+            {
+                window.Exit();
+            }
+            catch
+            {
+                RemoveWindow(window);
+            }
+        }
+    }
+
+    private static bool HasContentDockable(IDockable dockable)
+    {
+        if (dockable is ITool or IDocument) return true;
+        if (dockable is IDock { VisibleDockables: { } visibleDockables })
+            return visibleDockables.Any(HasContentDockable);
+        return false;
+    }
+
     public void RegisterDocumentView<T>(params string[] extensions) where T : IExtendedDocument
     {
         foreach (var extension in extensions) _documentViewRegistrations.TryAdd(extension, typeof(T));
@@ -523,6 +579,11 @@ public class MainDockService : Factory, IMainDockService
         var mainLayout = SearchView<ProportionalDock>().FirstOrDefault(p => p.Id == "MainLayout");
         if (mainLayout != null)
         {
+            // Track the dock the new proportional dock is actually parented under so
+            // its Owner is initialized correctly. Passing the wrong owner here leaves
+            // the docking tree inconsistent and breaks subsequent open/close cycles.
+            ProportionalDock? actualParent = null;
+
             if (location == DockShowLocation.Left)
             {
                 // Insert at the beginning
@@ -531,25 +592,32 @@ public class MainDockService : Factory, IMainDockService
                 {
                     mainLayout.VisibleDockables.Insert(1, new ProportionalDockSplitter());
                 }
+
+                actualParent = mainLayout;
             }
-            else if (location == DockShowLocation.Bottom || location == DockShowLocation.Right)
+            else if (location == DockShowLocation.Bottom)
             {
                 // Find RightPane and add bottom dock to it
                 var rightPane = SearchView<ProportionalDock>().FirstOrDefault(p => p.Id == "RightPane");
-                if (rightPane != null && location == DockShowLocation.Bottom)
+                if (rightPane != null)
                 {
                     rightPane.VisibleDockables?.Add(new ProportionalDockSplitter());
                     rightPane.VisibleDockables?.Add(proportionalDock);
-                }
-                else if (location == DockShowLocation.Right)
-                {
-                    mainLayout.VisibleDockables?.Add(new ProportionalDockSplitter());
-                    mainLayout.VisibleDockables?.Add(proportionalDock);
+                    actualParent = rightPane;
                 }
             }
+            else if (location == DockShowLocation.Right)
+            {
+                mainLayout.VisibleDockables?.Add(new ProportionalDockSplitter());
+                mainLayout.VisibleDockables?.Add(proportionalDock);
+                actualParent = mainLayout;
+            }
 
-            InitActiveDockable(proportionalDock, mainLayout);
-            return proportionalDock;
+            if (actualParent != null)
+            {
+                InitActiveDockable(proportionalDock, actualParent);
+                return proportionalDock;
+            }
         }
 
         return null;
@@ -622,7 +690,31 @@ public class MainDockService : Factory, IMainDockService
 
         layout.Id = name;
 
-        InitLayout(layout);
+        // Drop dockables that failed to deserialize (e.g. types from an
+        // uninstalled or renamed plugin). Their JSON $type cannot be resolved and
+        // the serializer leaves null entries in the layout. Passing those to
+        // InitLayout throws a NullReferenceException and prevents the app from
+        // starting. Removing them lets the rest of the saved layout load.
+        RemoveInvalidDockables(layout);
+
+        try
+        {
+            InitLayout(layout);
+        }
+        catch (Exception e)
+        {
+            ContainerLocator.Container.Resolve<ILogger>()
+                ?.Warning("Could not initialize saved layout! Loading default layout...", e);
+
+            // The saved layout is corrupted beyond repair, fall back to default.
+            layout = DefaultLayout.GetDefaultLayout(this);
+            layout.Id = name;
+            OpenFiles.Clear();
+            Show(_welcomeScreenViewModel, DockShowLocation.Document);
+            InitLayout(layout);
+            Layout = layout;
+            return;
+        }
 
         Layout = layout;
         
@@ -632,6 +724,42 @@ public class MainDockService : Factory, IMainDockService
         {
             MergeLayoutRegistrations();
         }
+    }
+
+    /// <summary>
+    /// Recursively removes null dockables from a layout tree. Null entries occur
+    /// when a saved dockable references a type that can no longer be resolved
+    /// (for example a plugin that was uninstalled or renamed).
+    /// </summary>
+    private static void RemoveInvalidDockables(IDockable? dockable)
+    {
+        if (dockable is IRootDock rootDock)
+        {
+            RemoveNullEntries(rootDock.LeftPinnedDockables);
+            RemoveNullEntries(rootDock.RightPinnedDockables);
+            RemoveNullEntries(rootDock.TopPinnedDockables);
+            RemoveNullEntries(rootDock.BottomPinnedDockables);
+            RemoveNullEntries(rootDock.HiddenDockables);
+
+            if (rootDock.Windows != null)
+                foreach (var window in rootDock.Windows)
+                    RemoveInvalidDockables(window.Layout);
+        }
+
+        if (dockable is IDock { VisibleDockables: { } visibleDockables } dock)
+        {
+            RemoveNullEntries(visibleDockables);
+            foreach (var child in dock.VisibleDockables!.ToList())
+                RemoveInvalidDockables(child);
+        }
+    }
+
+    private static void RemoveNullEntries(IList<IDockable>? list)
+    {
+        if (list == null) return;
+        for (var i = list.Count - 1; i >= 0; i--)
+            if (list[i] is null)
+                list.RemoveAt(i);
     }
     
     private void MergeLayoutRegistrations()

--- a/src/OneWare.Core/Services/MainDockService.cs
+++ b/src/OneWare.Core/Services/MainDockService.cs
@@ -419,8 +419,10 @@ public class MainDockService : Factory, IMainDockService
             var toolDock = FindOrCreateToolDock(location);
             if (toolDock != null)
             {
-                toolDock.VisibleDockables?.Add(dockable);
-                InitActiveDockable(dockable, toolDock);
+                // Use AddDockable (not a raw VisibleDockables.Add) so the dock's
+                // IsEmpty flag and owner chain are updated. A raw add leaves the
+                // tool dock flagged empty and it renders with zero size (issue #258).
+                AddDockable(toolDock, dockable);
                 SetActiveDockable(dockable);
             }
             else
@@ -511,6 +513,7 @@ public class MainDockService : Factory, IMainDockService
         {
             Id = dockId,
             Title = dockId,
+            Proportion = double.NaN,
             VisibleDockables = CreateList<IDockable>(),
             Alignment = alignment
         };
@@ -535,8 +538,9 @@ public class MainDockService : Factory, IMainDockService
 
             if (parentDock != null)
             {
-                parentDock.VisibleDockables?.Add(toolDock);
-                InitActiveDockable(toolDock, parentDock);
+                // AddDockable updates IsEmpty and the owner chain; a raw add leaves
+                // the parent flagged empty so it renders with zero size (issue #258).
+                AddDockable(parentDock, toolDock);
                 return toolDock;
             }
         }
@@ -586,12 +590,13 @@ public class MainDockService : Factory, IMainDockService
 
             if (location == DockShowLocation.Left)
             {
-                // Insert at the beginning
-                mainLayout.VisibleDockables?.Insert(0, proportionalDock);
+                // Existing siblings should auto-distribute the remaining space; leaving
+                // a stale proportion on them (or 0 on the new dock) makes the pane
+                // render with zero width (issue #258).
+                ResetChildProportions(mainLayout);
+                InsertDockable(mainLayout, proportionalDock, 0);
                 if (mainLayout.VisibleDockables?.Count > 1)
-                {
-                    mainLayout.VisibleDockables.Insert(1, new ProportionalDockSplitter());
-                }
+                    InsertDockable(mainLayout, new ProportionalDockSplitter(), 1);
 
                 actualParent = mainLayout;
             }
@@ -601,26 +606,39 @@ public class MainDockService : Factory, IMainDockService
                 var rightPane = SearchView<ProportionalDock>().FirstOrDefault(p => p.Id == "RightPane");
                 if (rightPane != null)
                 {
-                    rightPane.VisibleDockables?.Add(new ProportionalDockSplitter());
-                    rightPane.VisibleDockables?.Add(proportionalDock);
+                    ResetChildProportions(rightPane);
+                    AddDockable(rightPane, new ProportionalDockSplitter());
+                    AddDockable(rightPane, proportionalDock);
                     actualParent = rightPane;
                 }
             }
             else if (location == DockShowLocation.Right)
             {
-                mainLayout.VisibleDockables?.Add(new ProportionalDockSplitter());
-                mainLayout.VisibleDockables?.Add(proportionalDock);
+                ResetChildProportions(mainLayout);
+                AddDockable(mainLayout, new ProportionalDockSplitter());
+                AddDockable(mainLayout, proportionalDock);
                 actualParent = mainLayout;
             }
 
             if (actualParent != null)
-            {
-                InitActiveDockable(proportionalDock, actualParent);
                 return proportionalDock;
-            }
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Resets the proportion of a dock's non-splitter children to NaN so the
+    /// proportional layout redistributes space evenly. Without this, a stale or
+    /// zero proportion left over from a collapsed dock causes a newly inserted
+    /// sibling to render with zero size.
+    /// </summary>
+    private static void ResetChildProportions(ProportionalDock dock)
+    {
+        if (dock.VisibleDockables == null) return;
+        foreach (var child in dock.VisibleDockables)
+            if (child is not IProportionalDockSplitter)
+                child.Proportion = double.NaN;
     }
 
     private void AddPinnedDockable(IDockable dockable, DockShowLocation location)

--- a/tests/OneWare.Dock.HeadlessTests/DockReopenRenderTests.cs
+++ b/tests/OneWare.Dock.HeadlessTests/DockReopenRenderTests.cs
@@ -1,0 +1,225 @@
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Dock.Avalonia.Controls;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+using Dock.Model.Mvvm;
+using Dock.Model.Mvvm.Controls;
+using Xunit;
+
+namespace OneWareDockHeadlessTests;
+
+/// <summary>
+/// Headless regression test for issue #258: after closing all tools in a base
+/// tool dock the pane is removed from the layout, and reopening a tool must make
+/// it render again. This exercises the real Avalonia <see cref="DockControl"/> and
+/// mirrors the reopen logic in <c>MainDockService</c>.
+///
+/// The original bug: reopening rebuilt the docks with raw
+/// <c>VisibleDockables.Insert/Add</c> calls, which left <c>IsEmpty</c> stale and
+/// the proportions at 0, so the recreated pane rendered with zero size. The fix
+/// uses the factory's <c>AddDockable</c>/<c>InsertDockable</c> and resets sibling
+/// proportions.
+/// </summary>
+public class DockReopenRenderTests
+{
+    private sealed class TestFactory : Factory;
+
+    private static (Window window, RootDock root, TestFactory factory) CreateHosted()
+    {
+        var factory = new TestFactory();
+
+        var leftTool = new ToolDock
+        {
+            Id = "LeftPaneTop", Title = "LeftPaneTop", Alignment = Alignment.Left,
+            VisibleDockables = factory.CreateList<IDockable>(
+                new Tool { Id = "Tool1", Title = "Tool1" },
+                new Tool { Id = "Tool2", Title = "Tool2" })
+        };
+
+        var left = new ProportionalDock
+        {
+            Id = "LeftPane", Title = "LeftPane", Proportion = 0.25,
+            Orientation = Orientation.Vertical,
+            VisibleDockables = factory.CreateList<IDockable>(leftTool)
+        };
+
+        var bottomTool = new ToolDock
+        {
+            Id = "BottomPaneOne", Title = "BottomPaneOne", Alignment = Alignment.Bottom,
+            VisibleDockables = factory.CreateList<IDockable>(
+                new Tool { Id = "BTool1", Title = "BTool1" })
+        };
+
+        var bottom = new ProportionalDock
+        {
+            Id = "BottomRow", Title = "BottomRow", Proportion = 0.3,
+            Orientation = Orientation.Horizontal,
+            VisibleDockables = factory.CreateList<IDockable>(bottomTool)
+        };
+
+        var documentDock = new DocumentDock
+        {
+            Id = "Documents", Title = "Documents", IsCollapsable = false,
+            VisibleDockables = factory.CreateList<IDockable>()
+        };
+
+        var right = new ProportionalDock
+        {
+            Id = "RightPane", Title = "RightPane", Orientation = Orientation.Vertical,
+            VisibleDockables = factory.CreateList<IDockable>(
+                documentDock, new ProportionalDockSplitter(), bottom)
+        };
+
+        var mainLayout = new ProportionalDock
+        {
+            Id = "MainLayout", Title = "MainLayout", Orientation = Orientation.Horizontal,
+            VisibleDockables = factory.CreateList<IDockable>(
+                left, new ProportionalDockSplitter(), right)
+        };
+
+        var root = new RootDock
+        {
+            Id = "Root", Title = "Root", IsCollapsable = false,
+            VisibleDockables = factory.CreateList<IDockable>(mainLayout),
+            ActiveDockable = mainLayout, DefaultDockable = mainLayout,
+            LeftPinnedDockables = factory.CreateList<IDockable>(),
+            RightPinnedDockables = factory.CreateList<IDockable>(),
+            TopPinnedDockables = factory.CreateList<IDockable>(),
+            BottomPinnedDockables = factory.CreateList<IDockable>()
+        };
+
+        factory.InitLayout(root);
+
+        var dockControl = new DockControl { Factory = factory, Layout = root };
+        var window = new Window { Width = 1000, Height = 700, Content = dockControl };
+        window.Show();
+        Pump(window);
+
+        return (window, root, factory);
+    }
+
+    private static void Pump(Window window)
+    {
+        Dispatcher.UIThread.RunJobs();
+        window.Measure(new Size(1000, 700));
+        window.Arrange(new Rect(0, 0, 1000, 700));
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static IEnumerable<T> SearchView<T>(IDockable? layout)
+    {
+        if (layout is IDock { VisibleDockables: not null } dock)
+            foreach (var dockable in dock.VisibleDockables)
+            {
+                if (dockable is IDock sub)
+                    foreach (var bs in SearchView<T>(sub))
+                        yield return bs;
+                if (dockable is T tx)
+                    yield return tx;
+            }
+    }
+
+    private static bool ToolIsRendered(Window window, string toolTitle)
+    {
+        Pump(window);
+        return window.GetVisualDescendants()
+            .OfType<Control>()
+            .Any(c => c.DataContext is Tool t && t.Title == toolTitle
+                      && c.Bounds is { Width: > 0, Height: > 0 });
+    }
+
+    private static void ResetChildProportions(ProportionalDock dock)
+    {
+        if (dock.VisibleDockables == null) return;
+        foreach (var child in dock.VisibleDockables)
+            if (child is not IProportionalDockSplitter)
+                child.Proportion = double.NaN;
+    }
+
+    // Mirrors MainDockService.Show/FindOrCreateToolDock recreation for the left pane.
+    private static void ReopenLeft(TestFactory factory, RootDock root, Tool tool)
+    {
+        var mainLayout = SearchView<ProportionalDock>(root).First(p => p.Id == "MainLayout");
+        var toolDock = SearchView<ToolDock>(root).FirstOrDefault(t => t.Id == "LeftPaneTop");
+        if (toolDock == null)
+        {
+            toolDock = new ToolDock
+            {
+                Id = "LeftPaneTop", Title = "LeftPaneTop", Alignment = Alignment.Left,
+                Proportion = double.NaN, VisibleDockables = factory.CreateList<IDockable>()
+            };
+            var parentDock = SearchView<ProportionalDock>(root).FirstOrDefault(p => p.Id == "LeftPane");
+            if (parentDock == null)
+            {
+                parentDock = new ProportionalDock
+                {
+                    Id = "LeftPane", Title = "LeftPane", Proportion = 0.25,
+                    Orientation = Orientation.Vertical, VisibleDockables = factory.CreateList<IDockable>()
+                };
+                ResetChildProportions(mainLayout);
+                factory.InsertDockable(mainLayout, parentDock, 0);
+                if (mainLayout.VisibleDockables!.Count > 1)
+                    factory.InsertDockable(mainLayout, new ProportionalDockSplitter(), 1);
+            }
+            factory.AddDockable(parentDock, toolDock);
+        }
+        factory.AddDockable(toolDock, tool);
+        factory.SetActiveDockable(tool);
+    }
+
+    [AvaloniaFact]
+    public void Tool_renders_initially()
+    {
+        var (window, _, _) = CreateHosted();
+        Assert.True(ToolIsRendered(window, "Tool1"), "Tool1 should render initially");
+    }
+
+    [AvaloniaFact]
+    public void Left_tool_can_be_reopened_after_closing_all()
+    {
+        var (window, root, factory) = CreateHosted();
+
+        var leftTool = SearchView<ToolDock>(root).First(t => t.Id == "LeftPaneTop");
+        var t1 = (Tool)leftTool.VisibleDockables![0];
+        var t2 = (Tool)leftTool.VisibleDockables![1];
+
+        factory.CloseDockable(t1);
+        factory.CloseDockable(t2);
+        Pump(window);
+        Assert.Null(SearchView<ToolDock>(root).FirstOrDefault(t => t.Id == "LeftPaneTop"));
+
+        ReopenLeft(factory, root, t1);
+
+        Assert.True(ToolIsRendered(window, "Tool1"),
+            "Tool1 must render after reopening once all left tools were closed (issue #258)");
+    }
+
+    [AvaloniaFact]
+    public void Left_tool_can_be_reopened_across_multiple_close_cycles()
+    {
+        var (window, root, factory) = CreateHosted();
+
+        var leftTool = SearchView<ToolDock>(root).First(t => t.Id == "LeftPaneTop");
+        var t1 = (Tool)leftTool.VisibleDockables![0];
+        var t2 = (Tool)leftTool.VisibleDockables![1];
+
+        factory.CloseDockable(t1);
+        factory.CloseDockable(t2);
+        Pump(window);
+
+        ReopenLeft(factory, root, t1);
+        Assert.True(ToolIsRendered(window, "Tool1"), "First reopen cycle failed");
+
+        factory.CloseDockable(t1);
+        Pump(window);
+
+        ReopenLeft(factory, root, t2);
+        Assert.True(ToolIsRendered(window, "Tool2"), "Second reopen cycle failed");
+    }
+}

--- a/tests/OneWare.Dock.HeadlessTests/OneWare.Dock.HeadlessTests.csproj
+++ b/tests/OneWare.Dock.HeadlessTests/OneWare.Dock.HeadlessTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <Import Project="..\..\build\props\XUnit.props"/>
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <OutputType>Library</OutputType>
+        <IsPackable>False</IsPackable>
+        <IsTestProject>True</IsTestProject>
+        <Nullable>enable</Nullable>
+        <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Avalonia" Version="11.3.17"/>
+        <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.17"/>
+        <PackageReference Include="Avalonia.Themes.Simple" Version="11.3.17"/>
+        <PackageReference Include="Dock.Avalonia" Version="11.3.12.1"/>
+        <PackageReference Include="Dock.Model.Mvvm" Version="11.3.12.1"/>
+        <PackageReference Include="Dock.Avalonia.Themes.Simple" Version="11.3.12.1"/>
+    </ItemGroup>
+
+</Project>

--- a/tests/OneWare.Dock.HeadlessTests/TestApp.cs
+++ b/tests/OneWare.Dock.HeadlessTests/TestApp.cs
@@ -1,0 +1,26 @@
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Markup.Xaml.Styling;
+using OneWareDockHeadlessTests;
+
+[assembly: AvaloniaTestApplication(typeof(TestAppBuilder))]
+
+namespace OneWareDockHeadlessTests;
+
+public class TestApp : Application
+{
+    public override void Initialize()
+    {
+        Styles.Add(new global::Avalonia.Themes.Simple.SimpleTheme());
+        Styles.Add(new StyleInclude(new System.Uri("resm:Styles?assembly=OneWareDockHeadlessTests"))
+        {
+            Source = new System.Uri("avares://Dock.Avalonia.Themes.Simple/DockSimpleTheme.axaml")
+        });
+    }
+}
+
+public static class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<TestApp>().UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}


### PR DESCRIPTION
## Summary

Fixes three related Dock layout issues, including two of the latest open issues (#257, #258) and a startup crash reported after login when a saved layout references an uninstalled/renamed plugin type.

## Changes

All in `src/OneWare.Core/Services/MainDockService.cs`:

- **Startup crash on unresolved plugin types** — When a saved layout references a type that no longer resolves (e.g. `OneWare.AI.ViewModels.Pages.Wizard.WizardViewModel`), the serializer leaves `null` entries in the dockable lists and `InitLayout` throws a `NullReferenceException`, preventing the app from starting. `LoadLayout` now strips null dockables recursively (`RemoveInvalidDockables`) and wraps `InitLayout` in a try/catch that falls back to the default layout.
- **#258 — Tool windows can't be reopened reliably** — A recreated *bottom* `ProportionalDock` was added under `RightPane` but initialized with `MainLayout` as its owner, corrupting the docking tree so subsequent open/close cycles failed. It now initializes against its actual parent and only returns a dock that was really inserted.
- **#257 — Crash when closing a floating window** — Overrode `CloseDockable` to catch the `NullReferenceException` thrown by `Dock.Model.FactoryBase.CloseDockable` when closing the last dockable of a floating window, safely detach the dockable, and clean up now-empty float windows.

## Testing

- `dotnet build src/OneWare.Core/OneWare.Core.csproj` succeeds.
- The startup-crash fix directly matches the reported log.
- #257 and #258 should be smoke-tested in the running desktop app:
  - #258: close all left, then all bottom tool windows, reopen each from *View → Tool Windows*, repeat.
  - #257: float a tool (e.g. Explorer/Output) and close it via the title-bar X.

## Notes

- The #257 fix is a guarded recovery in OneWare; the root cause is in the `Dock.Avalonia` library. Given #257 notes it worked in 1.0.16, a `Dock.Avalonia` version bump may be worth investigating separately.

Closes #257
Closes #258