### PR TITLE
ci: dependency-scan release gate (CRA Annex I Part I(1))

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,6 +1,7 @@
 # Fails CI when OneWare Studio depends on a NuGet package with a known
 # vulnerability. Supports the EU Cyber Resilience Act (Regulation (EU) 2024/2847),
-# Annex I Part I(1) and Part II. See compliance/cra/ for details.
+# Annex I Part I(1) and Part II. Also exposed as a reusable workflow
+# (workflow_call) so the release pipeline can use it as a required gate.
 
 name: Dependency Vulnerability Scan
 
@@ -12,6 +13,7 @@ on:
   schedule:
     - cron: "17 6 * * 1"
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/publish-studio-all.yml
+++ b/.github/workflows/publish-studio-all.yml
@@ -5,8 +5,16 @@ on:
   workflow_dispatch:
 
 jobs:
+  # CRA Annex I Part I(1) release gate: block the release — and the platform
+  # publish pipelines that cascade from it — if any dependency has a known
+  # vulnerability.
+  scan:
+    name: Dependency vulnerability gate
+    uses: ./.github/workflows/dependency-scan.yml
+
   release:
     name: Release
+    needs: scan
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Makes the vulnerable-dependency scan a required release gate for OneWare Studio, closing the remaining EU CRA (Regulation (EU) 2024/2847) Annex I Part I(1) technical gap.

## Changes
- **Dependency scan as a required release gate**: `dependency-scan.yml` now also exposes `workflow_call`. `publish-studio-all.yml` runs it as a `scan` job and the `release` job `needs: scan`. A known-vulnerable NuGet dependency now **blocks the GitHub Release**, and since every platform publish requires `workflow_run.conclusion == 'success'`, the entire publish cascade is blocked too.
- Removed a stale internal `compliance/cra/` path reference from the scan comment.

## Note on SAST
CodeQL and secret scanning are enabled **organisation-wide via GitHub Advanced Security default setup**, so no repo-level CodeQL workflow is added here.

## CRA mapping
- Annex I Part I(1) — no known exploitable vulnerabilities at release (now enforced).
- Annex I Part II — vulnerability handling (dependency scanning + org-wide SAST).

No product code changes; CI only.