### PR TITLE
Fix AI terminal command reliability and cancellation

### DIFF
--- a/src/OneWare.Chat/Services/AiBuiltInFunctions.cs
+++ b/src/OneWare.Chat/Services/AiBuiltInFunctions.cs
@@ -13,6 +13,8 @@ internal static class AiBuiltInFunctions
     private const int MaxTerminalOutputLines = 220;
     private const int MaxTerminalOutputChars = 12000;
 
+    private static readonly TimeSpan TerminalCommandTimeout = TimeSpan.FromHours(12);
+
     public static void Register(
         IAiFunctionProvider functionProvider,
         IProjectExplorerService projectExplorerService,
@@ -149,8 +151,10 @@ internal static class AiBuiltInFunctions
                           """,
             Handler = ([Description("Shell command to execute")] string command,
                     [Description("Absolute working directory for execution (optional, defaults to active project).")]
-                    string? workDir = null) =>
-                RunTerminalCommandAsync(projectExplorerService, terminalManagerService, command, workDir),
+                    string? workDir = null,
+                    CancellationToken cancellationToken = default) =>
+                RunTerminalCommandAsync(projectExplorerService, terminalManagerService, command, workDir,
+                    cancellationToken),
             ConfirmationCheck = args =>
             {
                 var cmd = TryGetStringArgument(args, "command") ?? "?";
@@ -239,7 +243,8 @@ internal static class AiBuiltInFunctions
         IProjectExplorerService projectExplorerService,
         ITerminalManagerService terminalManagerService,
         string command,
-        string? workDir)
+        string? workDir,
+        CancellationToken cancellationToken)
     {
         var resolvedWorkDir = ResolvePath(projectExplorerService, workDir);
 
@@ -248,7 +253,8 @@ internal static class AiBuiltInFunctions
             "AI Chat",
             resolvedWorkDir,
             true,
-            TimeSpan.FromMinutes(1));
+            TerminalCommandTimeout,
+            cancellationToken);
 
         var truncatedOutput = TruncateTerminalOutput(terminalResult.Output, out var outputTruncated);
         var result = outputTruncated

--- a/src/OneWare.Terminal/Provider/Unix/UnixPseudoTerminal.cs
+++ b/src/OneWare.Terminal/Provider/Unix/UnixPseudoTerminal.cs
@@ -41,10 +41,36 @@ public class UnixPseudoTerminal : IPseudoTerminal
         await Task.Run(() =>
         {
             var buf = Marshal.AllocHGlobal(count);
-            Marshal.Copy(buffer, offset, buf, count);
-            Native.write(_cfg, buf, count);
+            try
+            {
+                Marshal.Copy(buffer, offset, buf, count);
 
-            Marshal.FreeHGlobal(buf);
+                // POSIX write() may perform a partial write or return -1 on EINTR/EAGAIN
+                // when the pty input buffer is momentarily full. Ignoring that dropped
+                // part of the command (often the trailing carriage return), leaving the
+                // shell waiting for input and the command hanging forever. Loop until
+                // every byte is written so command submission is reliable.
+                var written = 0;
+                var retries = 0;
+                while (written < count && !_isDisposed)
+                {
+                    var result = Native.write(_cfg, IntPtr.Add(buf, written), count - written);
+
+                    if (result > 0)
+                    {
+                        written += result;
+                        retries = 0;
+                        continue;
+                    }
+
+                    if (++retries > 1000) break;
+                    Thread.Sleep(1);
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buf);
+            }
         });
     }
 

--- a/src/OneWare.Terminal/ViewModels/TerminalViewModel.cs
+++ b/src/OneWare.Terminal/ViewModels/TerminalViewModel.cs
@@ -137,6 +137,13 @@ public class TerminalViewModel : ObservableObject
         if (Connection?.IsConnected ?? false) Connection.SendData(Encoding.ASCII.GetBytes($"{command}\r"));
     }
 
+    public void SendInterrupt()
+    {
+        // Send Ctrl+C (ETX) to abort the currently running foreground command
+        // so the shell returns to a usable prompt.
+        if (Connection?.IsConnected ?? false) Connection.SendData([0x03]);
+    }
+
     public void SuppressEcho(byte[] data)
     {
         if (Connection is IOutputSuppressor suppressor)

--- a/src/OneWare.TerminalManager/ViewModels/TerminalManagerViewModel.cs
+++ b/src/OneWare.TerminalManager/ViewModels/TerminalManagerViewModel.cs
@@ -168,7 +168,13 @@ public class TerminalManagerViewModel : ExtendedTool, ITerminalManagerService
         }
         catch (OperationCanceledException)
         {
-            result = new TerminalExecutionResult(output.ToString(), -1, true);
+            var partialOutput = output.ToString();
+            // The command exceeded its timeout or was cancelled but is still running
+            // in the shell. Interrupt it so the shell returns to a usable prompt;
+            // otherwise the foreground command keeps running and every subsequent
+            // command sent to this (reused) terminal hangs too.
+            await TryRecoverPromptAsync(terminal, resultTcs.Task);
+            result = new TerminalExecutionResult(partialOutput, -1, true);
         }
         finally
         {
@@ -177,6 +183,22 @@ public class TerminalManagerViewModel : ExtendedTool, ITerminalManagerService
         }
 
         return result;
+    }
+
+    private static async Task TryRecoverPromptAsync(TerminalViewModel terminal,
+        Task<TerminalExecutionResult> resultTask)
+    {
+        terminal.SendInterrupt();
+        try
+        {
+            // Give the shell a moment to process the interrupt and emit a fresh
+            // prompt marker so the terminal can be reused by the next command.
+            await resultTask.WaitAsync(TimeSpan.FromSeconds(3));
+        }
+        catch (TimeoutException)
+        {
+            // Best-effort recovery: fall through even if the shell did not respond.
+        }
     }
 
     public void ExecScriptInTerminal(string scriptPath, bool elevated, string title)


### PR DESCRIPTION
## Problem

AI terminal commands (`runTerminalCommand`) sometimes got stuck forever for seemingly no reason, even on simple commands. There was also no way to reliably cancel a running command, and the timeout was too short for long-running tasks.

## Root cause

`UnixPseudoTerminal.WriteAsync` ignored the return value of the POSIX `write(2)` call. `write()` may perform a **partial write** or return **-1** on `EINTR`/`EAGAIN` when the pty input buffer is momentarily full. When that happened, part of the command — often the trailing carriage return — was silently dropped, so the shell never executed the command, never emitted its completion marker, and the call hung until the timeout. Because it depends on buffer timing, it was intermittent and hit even trivial commands.

## Changes

- **Reliable command submission** — `UnixPseudoTerminal.WriteAsync` now loops until every byte is written, advancing on partial writes and retrying on transient failures.
- **Long-running task support** — the `runTerminalCommand` timeout is raised from 1 minute to 12 hours so builds/simulations/servers aren't killed prematurely.
- **Stop button cancels the command** — the tool handler now takes a `CancellationToken` (auto-bound by `AIFunctionFactory` to the token the Copilot SDK cancels on `AbortAsync`) and threads it into `ExecuteInTerminalAsync`.
- **Interrupt & recover** — on timeout/cancel, the shell is sent Ctrl+C (`TerminalViewModel.SendInterrupt`) and given a moment to return to a clean prompt, so the reused automation terminal doesn't stay stuck for subsequent commands.

## Testing

- `dotnet build` succeeds for `OneWare.Terminal`, `OneWare.TerminalManager`, and `OneWare.Chat` (only pre-existing warnings).