### PR TITLE
Force-kill stuck AI terminal commands

### DIFF
--- a/src/OneWare.Terminal/Provider/PseudoTerminalConnection.cs
+++ b/src/OneWare.Terminal/Provider/PseudoTerminalConnection.cs
@@ -61,6 +61,19 @@ public class PseudoTerminalConnection(IPseudoTerminal terminal) : IConnection, I
         _ = terminal.WriteAsync(data, 0, data.Length);
     }
 
+    public void KillProcess()
+    {
+        try
+        {
+            if (!terminal.Process.HasExited)
+                terminal.Process.Kill(true);
+        }
+        catch
+        {
+            // Best effort: the process may already have exited or be unkillable.
+        }
+    }
+
     public void SuppressOutput(byte[] sequence)
     {
         if (sequence.Length == 0) return;

--- a/src/OneWare.Terminal/ViewModels/TerminalViewModel.cs
+++ b/src/OneWare.Terminal/ViewModels/TerminalViewModel.cs
@@ -144,6 +144,13 @@ public class TerminalViewModel : ObservableObject
         if (Connection?.IsConnected ?? false) Connection.SendData([0x03]);
     }
 
+    public void KillProcess()
+    {
+        // Forcibly terminate the shell and any child processes. Used as a last
+        // resort when an interrupt (Ctrl+C) fails to free a stuck command.
+        if (Connection is PseudoTerminalConnection ptc) ptc.KillProcess();
+    }
+
     public void SuppressEcho(byte[] data)
     {
         if (Connection is IOutputSuppressor suppressor)

--- a/src/OneWare.TerminalManager/ViewModels/TerminalManagerViewModel.cs
+++ b/src/OneWare.TerminalManager/ViewModels/TerminalManagerViewModel.cs
@@ -170,10 +170,18 @@ public class TerminalManagerViewModel : ExtendedTool, ITerminalManagerService
         {
             var partialOutput = output.ToString();
             // The command exceeded its timeout or was cancelled but is still running
-            // in the shell. Interrupt it so the shell returns to a usable prompt;
-            // otherwise the foreground command keeps running and every subsequent
-            // command sent to this (reused) terminal hangs too.
-            await TryRecoverPromptAsync(terminal, resultTcs.Task);
+            // in the shell. First try a gentle interrupt (Ctrl+C) so the shell returns
+            // to a usable prompt and the terminal stays reusable.
+            var recovered = await TryRecoverPromptAsync(terminal, resultTcs.Task);
+            if (!recovered)
+            {
+                // The interrupt did not free the shell (the process ignores SIGINT or is
+                // itself hung). Forcibly kill the process tree and discard this terminal
+                // so it is never reused in a stuck state by a subsequent command.
+                terminal.KillProcess();
+                DiscardAutomationTerminal(terminal);
+            }
+
             result = new TerminalExecutionResult(partialOutput, -1, true);
         }
         finally
@@ -185,7 +193,7 @@ public class TerminalManagerViewModel : ExtendedTool, ITerminalManagerService
         return result;
     }
 
-    private static async Task TryRecoverPromptAsync(TerminalViewModel terminal,
+    private static async Task<bool> TryRecoverPromptAsync(TerminalViewModel terminal,
         Task<TerminalExecutionResult> resultTask)
     {
         terminal.SendInterrupt();
@@ -194,11 +202,21 @@ public class TerminalManagerViewModel : ExtendedTool, ITerminalManagerService
             // Give the shell a moment to process the interrupt and emit a fresh
             // prompt marker so the terminal can be reused by the next command.
             await resultTask.WaitAsync(TimeSpan.FromSeconds(3));
+            return true;
         }
         catch (TimeoutException)
         {
-            // Best-effort recovery: fall through even if the shell did not respond.
+            return false;
         }
+    }
+
+    private void DiscardAutomationTerminal(TerminalViewModel terminal)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            var tab = Terminals.FirstOrDefault(t => ReferenceEquals(t.Terminal, terminal));
+            tab?.Close();
+        });
     }
 
     public void ExecScriptInTerminal(string scriptPath, bool elevated, string title)


### PR DESCRIPTION
## Problem

A `runTerminalCommand` could open a terminal tab, get stuck forever, and be impossible to escape — even the stop button / manual Ctrl+C couldn't recover it. Because the AI reuses the same automation terminal, once it was stuck every subsequent command hung too.

## Investigation

The keyboard input path is sound (Ctrl+C maps to `\u0003`, the terminal control is `Focusable`), and pressing Ctrl+C in a healthy shell does recover it. The unrecoverable case is when the running process **ignores SIGINT** or the shell itself is hung — the previous gentle-interrupt recovery had no fallback, so the terminal stayed stuck and poisoned all later commands.

## Changes

On cancellation/timeout the shell is still sent Ctrl+C first (keeps the terminal reusable for well-behaved commands). If it does **not** return to a usable prompt within the grace period:

- `PseudoTerminalConnection.KillProcess` forcibly kills the shell and its entire child process tree.
- `TerminalViewModel.KillProcess` exposes this to the manager.
- `TerminalManagerViewModel` kills the process tree **and discards** the stuck automation terminal, so the next AI command always starts from a fresh, responsive terminal instead of reusing a hung one.

This guarantees a stuck command can always be terminated (via the Copilot stop button, which cancels the tool's `CancellationToken`), and that the AI terminal never stays permanently wedged.

## Testing

- `dotnet build src/OneWare.TerminalManager` succeeds (only pre-existing warnings).