### PR TITLE
Improve AI terminal reliability and streaming

### DIFF
--- a/docs/PluginDevelopment.md
+++ b/docs/PluginDevelopment.md
@@ -248,8 +248,9 @@ Provides all app path locations: `AppDataDirectory`, `ProjectsDirectory`, `Packa
 
 #### `ITerminalManagerService` (src/OneWare.Essentials/Services/ITerminalManagerService.cs)
 
-- `ExecuteInTerminalAsync(command, id, workingDirectory, showInUi, timeout, cancellationToken)`:
-  run a command in a terminal pane and return the result.
+- `ExecuteInTerminalAsync(command, id, workingDirectory, showInUi, timeout, outputProgress, cancellationToken)`:
+  run a command in a terminal pane and return the result. Pass an optional `IProgress<string>`
+  as `outputProgress` to receive the accumulated output in real time while the command runs.
 
 #### `IToolService` (src/OneWare.Essentials/Services/IToolService.cs)
 
@@ -323,8 +324,13 @@ Provides all app path locations: `AppDataDirectory`, `ProjectsDirectory`, `Packa
 
 #### `IAiFunctionProvider` (src/OneWare.Essentials/Services/IAiFunctionProvider.cs)
 
-- `GetTools()`: register AI tools for chat or automation.
-- `FunctionStarted`, `FunctionCompleted` events.
+- `RegisterFunction(IOneWareAiFunction)`: register an AI tool.
+- `GetTools()`: return the registered tools for chat or automation.
+- `FunctionStarted`, `FunctionProgress`, `FunctionCompleted` events identify each concurrent
+  invocation by its unique ID.
+- Set `OneWareAiFunction.InvocationHandler` when a tool needs an
+  `AiFunctionInvocationContext` for invocation-scoped progress reporting. Keep `Handler` as the
+  typed delegate used to generate the tool schema.
 
 #### `ISerialMonitorService` (src/OneWare.Essentials/Services/ISerialMonitorService.cs)
 

--- a/src/OneWare.Chat/Services/AiBuiltInFunctions.cs
+++ b/src/OneWare.Chat/Services/AiBuiltInFunctions.cs
@@ -159,7 +159,16 @@ internal static class AiBuiltInFunctions
                     [Description("Absolute working directory for execution (optional, defaults to active project).")]
                     string? workDir = null,
                     CancellationToken cancellationToken = default) =>
-                RunTerminalCommandAsync(projectExplorerService, terminalManagerService, command, workDir,
+                RunTerminalCommandAsync(projectExplorerService, terminalManagerService, null, command,
+                    workDir, cancellationToken),
+            InvocationHandler = async (context, args, cancellationToken) =>
+                await RunTerminalCommandAsync(
+                    projectExplorerService,
+                    terminalManagerService,
+                    context,
+                    TryGetStringArgument(args, "command")
+                    ?? throw new ArgumentException("A terminal command is required.", "command"),
+                    TryGetStringArgument(args, "workDir"),
                     cancellationToken),
             DetailExtractor = args => TryGetStringArgument(args, "command"),
             ConfirmationCheck = args =>
@@ -250,11 +259,16 @@ internal static class AiBuiltInFunctions
     private static async Task<object> RunTerminalCommandAsync(
         IProjectExplorerService projectExplorerService,
         ITerminalManagerService terminalManagerService,
+        AiFunctionInvocationContext? context,
         string command,
         string? workDir,
         CancellationToken cancellationToken)
     {
         var resolvedWorkDir = ResolvePath(projectExplorerService, workDir);
+
+        var progress = context == null
+            ? null
+            : new DelegateProgress(raw => context.ReportProgress(FormatTerminalProgress(command, raw)));
 
         var terminalResult = await terminalManagerService.ExecuteInTerminalAsync(
             command,
@@ -262,6 +276,7 @@ internal static class AiBuiltInFunctions
             resolvedWorkDir,
             true,
             TerminalCommandTimeout,
+            progress,
             cancellationToken);
 
         var truncatedOutput = TruncateTerminalOutput(terminalResult.Output, out var outputTruncated);
@@ -269,12 +284,43 @@ internal static class AiBuiltInFunctions
             ? terminalResult with { Output = truncatedOutput }
             : terminalResult;
 
+        // Show the final, cleaned output in the chat tool box.
+        context?.ReportProgress(FormatTerminalProgress(command, terminalResult.Output));
+
         return new
         {
             result,
             outputTruncated,
             originalOutputLength = terminalResult.Output.Length
         };
+    }
+
+    private static string FormatTerminalProgress(string command, string rawOutput)
+    {
+        var cleaned = StripAnsiEscapes(rawOutput);
+        var truncated = TruncateTerminalOutput(cleaned, out _);
+        return string.IsNullOrEmpty(truncated)
+            ? $"$ {command}"
+            : $"$ {command}\n{truncated}";
+    }
+
+    private static readonly System.Text.RegularExpressions.Regex AnsiEscapeRegex =
+        new(@"\x1B\][^\x07\x1B]*(?:\x07|\x1B\\)|\x1B[@-Z\\-_]|\x1B\[[0-9;?]*[ -/]*[@-~]",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    private static string StripAnsiEscapes(string input)
+    {
+        if (string.IsNullOrEmpty(input)) return input;
+
+        var stripped = AnsiEscapeRegex.Replace(input, string.Empty);
+        // Normalise carriage returns: terminals use them for in-place redraws (e.g. progress
+        // bars); collapsing them keeps the plain-text readout readable.
+        return stripped.Replace("\r\n", "\n").Replace("\r", string.Empty);
+    }
+
+    private sealed class DelegateProgress(Action<string> onReport) : IProgress<string>
+    {
+        public void Report(string value) => onReport(value);
     }
 
     private static string TruncateTerminalOutput(string output, out bool wasTruncated)

--- a/src/OneWare.Chat/Services/AiFunctionProvider.cs
+++ b/src/OneWare.Chat/Services/AiFunctionProvider.cs
@@ -20,6 +20,7 @@ public class AiFunctionProvider(
 
     public event EventHandler<AiFunctionStartedEvent>? FunctionStarted;
     public event EventHandler<AiFunctionCompletedEvent>? FunctionCompleted;
+    public event EventHandler<AiFunctionProgressEvent>? FunctionProgress;
 
     public void RegisterFunction(IOneWareAiFunction function)
     {
@@ -133,6 +134,16 @@ public class AiFunctionProvider(
             }));
     }
 
+    private void RaiseFunctionProgress(string id, string output)
+    {
+        Dispatcher.UIThread.Post(() =>
+            FunctionProgress?.Invoke(this, new AiFunctionProgressEvent
+            {
+                Id = id,
+                Output = output
+            }));
+    }
+
     private sealed class RegisteredOneWareAiFunction(
         AiFunctionProvider provider,
         AIFunction innerFunction,
@@ -147,16 +158,18 @@ public class AiFunctionProvider(
 
             var detail = definition.DetailExtractor?.Invoke(arguments);
             var id = await provider.NotifyFunctionStartedAsync(friendlyName!, detail);
+            var context = new AiFunctionInvocationContext(id,
+                output => provider.RaiseFunctionProgress(id, output));
             Exception? exception = null;
             try
             {
                 if (definition.RunOnUiThread)
                 {
                     return await Dispatcher.UIThread.InvokeAsync(async () =>
-                        await base.InvokeCoreAsync(arguments, cancellationToken));
+                        await InvokeDefinitionAsync(context, arguments, cancellationToken));
                 }
 
-                return await base.InvokeCoreAsync(arguments, cancellationToken);
+                return await InvokeDefinitionAsync(context, arguments, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -167,6 +180,14 @@ public class AiFunctionProvider(
             {
                 await provider.NotifyFunctionCompletedAsync(id, exception);
             }
+        }
+
+        private ValueTask<object?> InvokeDefinitionAsync(AiFunctionInvocationContext context,
+            AIFunctionArguments arguments, CancellationToken cancellationToken)
+        {
+            return definition.InvocationHandler != null
+                ? definition.InvocationHandler(context, arguments, cancellationToken)
+                : base.InvokeCoreAsync(arguments, cancellationToken);
         }
     }
 }

--- a/src/OneWare.Chat/ViewModels/ChatMessages/ChatMessageToolViewModel.cs
+++ b/src/OneWare.Chat/ViewModels/ChatMessages/ChatMessageToolViewModel.cs
@@ -19,7 +19,11 @@ public class ChatMessageToolViewModel : ObservableObject, IChatMessage, IEstimat
     public string ToolName { get; }
     
     [DataMember]
-    public string? ToolOutput { get; set; }
+    public string? ToolOutput
+    {
+        get;
+        set => SetProperty(ref field, value);
+    }
     
     public DateTimeOffset Timestamp { get; }
 

--- a/src/OneWare.Chat/ViewModels/ChatViewModel.cs
+++ b/src/OneWare.Chat/ViewModels/ChatViewModel.cs
@@ -58,6 +58,7 @@ public partial class ChatViewModel : ExtendedTool, IChatManagerService
 
         aiFunctionProvider.FunctionStarted += OnFunctionStarted;
         aiFunctionProvider.FunctionCompleted += OnFunctionCompleted;
+        aiFunctionProvider.FunctionProgress += OnFunctionProgress;
 
         _mainDockService = mainDockService;
 
@@ -661,6 +662,14 @@ public partial class ChatViewModel : ExtendedTool, IChatManagerService
                 toolFinished.ToolOutput += '\n';
             toolFinished.ToolOutput += function.ToolOutput;
         }
+    }
+
+    private void OnFunctionProgress(object? sender, AiFunctionProgressEvent progress)
+    {
+        var tool = Messages.OfType<ChatMessageToolViewModel>().LastOrDefault(x => x.Id == progress.Id);
+        if (tool == null || !tool.IsToolRunning) return;
+
+        tool.ToolOutput = progress.Output;
     }
 
     private void ShowEdit(AiEditViewModel? editViewModel)

--- a/src/OneWare.Chat/Views/ChatMessages/ChatMessageToolView.axaml
+++ b/src/OneWare.Chat/Views/ChatMessages/ChatMessageToolView.axaml
@@ -26,7 +26,11 @@
         </Expander.Header>
         <Border Margin="1 4 1 0" Background="{DynamicResource ThemeControlMidBrush}" Classes="RoundBorder"
                 MaxHeight="200" Padding="5">
-            <SelectableTextBlock TextWrapping="Wrap" Text="{Binding ToolOutput}" />
+            <ScrollViewer x:Name="OutputScrollViewer" HorizontalScrollBarVisibility="Disabled"
+                          VerticalScrollBarVisibility="Auto">
+                <SelectableTextBlock TextWrapping="Wrap" FontFamily="{DynamicResource EditorFont}"
+                                     Text="{Binding ToolOutput}" />
+            </ScrollViewer>
         </Border>
     </Expander>
 

--- a/src/OneWare.Chat/Views/ChatMessages/ChatMessageToolView.axaml.cs
+++ b/src/OneWare.Chat/Views/ChatMessages/ChatMessageToolView.axaml.cs
@@ -1,11 +1,36 @@
-﻿using Avalonia.Controls;
+using System.ComponentModel;
+using Avalonia.Controls;
+using OneWare.Chat.ViewModels.ChatMessages;
 
 namespace OneWare.Chat.Views.ChatMessages;
 
 public partial class ChatMessageToolView : UserControl
 {
+    private ChatMessageToolViewModel? _subscribed;
+
     public ChatMessageToolView()
     {
         InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (_subscribed != null)
+            _subscribed.PropertyChanged -= OnViewModelPropertyChanged;
+
+        _subscribed = DataContext as ChatMessageToolViewModel;
+
+        if (_subscribed != null)
+            _subscribed.PropertyChanged += OnViewModelPropertyChanged;
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (sender is not ChatMessageToolViewModel vm) return;
+        if (e.PropertyName != nameof(ChatMessageToolViewModel.ToolOutput)) return;
+        if (!vm.IsToolRunning) return;
+
+        OutputScrollViewer.ScrollToEnd();
     }
 }

--- a/src/OneWare.Essentials/Models/AiFunctionEvent.cs
+++ b/src/OneWare.Essentials/Models/AiFunctionEvent.cs
@@ -16,3 +16,8 @@ public class AiFunctionCompletedEvent : AiFunctionEvent
     public required bool Result { get; init; }
     public string? ToolOutput { get; init; }
 }
+
+public class AiFunctionProgressEvent : AiFunctionEvent
+{
+    public required string Output { get; init; }
+}

--- a/src/OneWare.Essentials/Models/OneWareAiFunction.cs
+++ b/src/OneWare.Essentials/Models/OneWareAiFunction.cs
@@ -24,6 +24,20 @@ public interface IOneWareAiFunction
     /// while the tool is running.
     /// </summary>
     Func<AIFunctionArguments, string?>? DetailExtractor { get; }
+
+    /// <summary>
+    /// Optional invocation handler for tools that need access to invocation-scoped services such
+    /// as progress reporting. <see cref="Handler"/> is still used to generate the AI tool schema.
+    /// </summary>
+    Func<AiFunctionInvocationContext, AIFunctionArguments, CancellationToken, ValueTask<object?>>?
+        InvocationHandler => null;
+}
+
+public sealed class AiFunctionInvocationContext(string id, Action<string> reportProgress)
+{
+    public string Id { get; } = id;
+
+    public void ReportProgress(string output) => reportProgress(output);
 }
 
 public sealed class OneWareAiFunction : IOneWareAiFunction
@@ -37,4 +51,7 @@ public sealed class OneWareAiFunction : IOneWareAiFunction
     public Func<AIFunctionArguments, string?>? ConfirmationCheck { get; init; }
     /// <inheritdoc />
     public Func<AIFunctionArguments, string?>? DetailExtractor { get; init; }
+    /// <inheritdoc />
+    public Func<AiFunctionInvocationContext, AIFunctionArguments, CancellationToken, ValueTask<object?>>?
+        InvocationHandler { get; init; }
 }

--- a/src/OneWare.Essentials/Services/IAiFunctionProvider.cs
+++ b/src/OneWare.Essentials/Services/IAiFunctionProvider.cs
@@ -9,6 +9,12 @@ public interface IAiFunctionProvider
     event EventHandler<AiFunctionStartedEvent>? FunctionStarted;
     /// <summary>Fired when an AI function completes.</summary>
     event EventHandler<AiFunctionCompletedEvent>? FunctionCompleted;
+    /// <summary>Fired when a running AI function reports incremental output.</summary>
+    event EventHandler<AiFunctionProgressEvent>? FunctionProgress
+    {
+        add { }
+        remove { }
+    }
 
     /// <summary>Returns available AI tools for this provider.</summary>
     ICollection<AIFunction> GetTools();

--- a/src/OneWare.Essentials/Services/ITerminalManagerService.cs
+++ b/src/OneWare.Essentials/Services/ITerminalManagerService.cs
@@ -8,6 +8,20 @@ public interface ITerminalManagerService : IDockable
     /// <summary>
     /// Executes a command in a terminal tab and returns the result.
     /// </summary>
+    /// <param name="outputProgress">
+    /// Optional sink that receives the accumulated terminal output as it streams in, enabling
+    /// real-time display while the command is still running.
+    /// </param>
     Task<TerminalExecutionResult> ExecuteInTerminalAsync(string command,
-        string id, string? workingDirectory = null, bool showInUi = false, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+        string id, string? workingDirectory = null, bool showInUi = false, TimeSpan? timeout = null,
+        IProgress<string>? outputProgress = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes a command in a terminal tab and returns the result.
+    /// </summary>
+    [Obsolete("Use the overload that accepts an IProgress<string> outputProgress parameter. " +
+              "This overload is kept for plugin binary compatibility and will be removed in a future release.")]
+    Task<TerminalExecutionResult> ExecuteInTerminalAsync(string command,
+        string id, string? workingDirectory, bool showInUi, TimeSpan? timeout,
+        CancellationToken cancellationToken);
 }

--- a/src/OneWare.ProjectExplorer/ViewModels/ProjectViewModelBase.cs
+++ b/src/OneWare.ProjectExplorer/ViewModels/ProjectViewModelBase.cs
@@ -102,6 +102,13 @@ public abstract class ProjectViewModelBase : ExtendedTool
     private List<int> GetIndexPathFromNode(IProjectExplorerNode node)
     {
         List<int> indexPath = [];
+
+        if (node is IProjectRoot root)
+        {
+            indexPath.Add(Projects.IndexOf(root));
+            return indexPath;
+        }
+
         if (node.Parent?.Children != null)
         {
             indexPath.Add(node.Parent.Children.IndexOf(node));

--- a/src/OneWare.Terminal/Provider/PseudoTerminalConnection.cs
+++ b/src/OneWare.Terminal/Provider/PseudoTerminalConnection.cs
@@ -158,6 +158,7 @@ public class PseudoTerminalConnection(IPseudoTerminal terminal) : IConnection, I
     private void Process_Exited(object? sender, EventArgs e)
     {
         terminal.Process.Exited -= Process_Exited;
+        _cancellationSource?.Cancel();
 
         Closed?.Invoke(this, EventArgs.Empty);
     }

--- a/src/OneWare.Terminal/Provider/Unix/Native.cs
+++ b/src/OneWare.Terminal/Provider/Unix/Native.cs
@@ -156,6 +156,7 @@ internal static class Native
     public static NativeDelegates.kill kill = NativeDelegates.GetProc<NativeDelegates.kill>();
     public static NativeDelegates.execve execve = NativeDelegates.GetProc<NativeDelegates.execve>();
     public static NativeDelegates.fork fork = NativeDelegates.GetProc<NativeDelegates.fork>();
+    public static NativeDelegates._exit _exit = NativeDelegates.GetProc<NativeDelegates._exit>();
 
     public static IntPtr StructToPtr<T>(T structure)
     {

--- a/src/OneWare.Terminal/Provider/Unix/UnixPseudoTerminalProvider.cs
+++ b/src/OneWare.Terminal/Provider/Unix/UnixPseudoTerminalProvider.cs
@@ -47,20 +47,26 @@ public class UnixPseudoTerminalProvider : IPseudoTerminalProvider
         envVars.Add("TERM=xterm-256color");
         envVars.Add(null!);
 
+        // Build all managed data (argv/env arrays, tokenization) in the PARENT before forking.
+        // After forkpty the child shares the address space of a multithreaded runtime whose GC
+        // and JIT locks may be held by other (now-frozen) threads. Running not-yet-JIT-compiled
+        // managed code or allocating there can deadlock or segfault (exit 139), so the child must
+        // only perform native calls on pre-built arrays.
+        var envArray = envVars.ToArray();
+
+        var argvList = new List<string> { command };
+        if (arguments != null) argvList.AddRange(TokenizeArguments(arguments));
+        argvList.Add(null!);
+        var argvArray = argvList.ToArray();
+
         var pid = Native.forkpty(out var masterFd, IntPtr.Zero, IntPtr.Zero, ref winsize);
 
         //pid will be 0 on the forked process
         if (pid == 0)
         {
             Native.chdir(initialDirectory);
-
-            var argsArray = new List<string> { command };
-            if (arguments != null) argsArray.AddRange(arguments.Split(' '));
-
-            argsArray.Add(null!);
-
-            Native.execve(argsArray[0], argsArray.ToArray(), envVars.ToArray());
-            Environment.Exit(1);
+            Native.execve(argvArray[0], argvArray, envArray);
+            Native._exit(1);
         }
 
         var stdin = Native.dup(masterFd);
@@ -68,5 +74,75 @@ public class UnixPseudoTerminalProvider : IPseudoTerminalProvider
 
         return new UnixPseudoTerminal(process, masterFd, new FileStream(new SafeFileHandle(new IntPtr(stdin), true),
             FileAccess.Write), new FileStream(new SafeFileHandle(new IntPtr(masterFd), true), FileAccess.Read));
+    }
+
+    private static IEnumerable<string> TokenizeArguments(string arguments)
+    {
+        var tokens = new List<string>();
+        var current = new System.Text.StringBuilder();
+        char? quote = null;
+        var escaped = false;
+        var hasToken = false;
+
+        foreach (var c in arguments)
+        {
+            if (escaped)
+            {
+                current.Append(c);
+                escaped = false;
+                hasToken = true;
+                continue;
+            }
+
+            if (c == '\\' && quote != '\'')
+            {
+                escaped = true;
+                hasToken = true;
+                continue;
+            }
+
+            if (quote != null)
+            {
+                if (c == quote)
+                {
+                    quote = null;
+                }
+                else
+                {
+                    current.Append(c);
+                }
+
+                hasToken = true;
+                continue;
+            }
+
+            switch (c)
+            {
+                case '"':
+                case '\'':
+                    quote = c;
+                    hasToken = true;
+                    break;
+                case var _ when char.IsWhiteSpace(c):
+                    if (hasToken)
+                    {
+                        tokens.Add(current.ToString());
+                        current.Clear();
+                        hasToken = false;
+                    }
+                    break;
+                default:
+                    current.Append(c);
+                    hasToken = true;
+                    break;
+            }
+        }
+
+        if (escaped || quote != null)
+            throw new FormatException("Terminal start arguments contain an incomplete escape or quoted value.");
+
+        if (hasToken) tokens.Add(current.ToString());
+
+        return tokens;
     }
 }

--- a/src/OneWare.Terminal/Provider/Unix/UnixPseudoTerminalProvider.cs
+++ b/src/OneWare.Terminal/Provider/Unix/UnixPseudoTerminalProvider.cs
@@ -47,7 +47,7 @@ public class UnixPseudoTerminalProvider : IPseudoTerminalProvider
         envVars.Add("TERM=xterm-256color");
         envVars.Add(null!);
 
-        // Build all managed data (argv/env arrays, tokenization) in the PARENT before forking.
+        // Build all managed data (argv/env arrays) in the PARENT before forking.
         // After forkpty the child shares the address space of a multithreaded runtime whose GC
         // and JIT locks may be held by other (now-frozen) threads. Running not-yet-JIT-compiled
         // managed code or allocating there can deadlock or segfault (exit 139), so the child must
@@ -55,7 +55,7 @@ public class UnixPseudoTerminalProvider : IPseudoTerminalProvider
         var envArray = envVars.ToArray();
 
         var argvList = new List<string> { command };
-        if (arguments != null) argvList.AddRange(TokenizeArguments(arguments));
+        if (arguments != null) argvList.AddRange(arguments.Split(' '));
         argvList.Add(null!);
         var argvArray = argvList.ToArray();
 
@@ -74,75 +74,5 @@ public class UnixPseudoTerminalProvider : IPseudoTerminalProvider
 
         return new UnixPseudoTerminal(process, masterFd, new FileStream(new SafeFileHandle(new IntPtr(stdin), true),
             FileAccess.Write), new FileStream(new SafeFileHandle(new IntPtr(masterFd), true), FileAccess.Read));
-    }
-
-    private static IEnumerable<string> TokenizeArguments(string arguments)
-    {
-        var tokens = new List<string>();
-        var current = new System.Text.StringBuilder();
-        char? quote = null;
-        var escaped = false;
-        var hasToken = false;
-
-        foreach (var c in arguments)
-        {
-            if (escaped)
-            {
-                current.Append(c);
-                escaped = false;
-                hasToken = true;
-                continue;
-            }
-
-            if (c == '\\' && quote != '\'')
-            {
-                escaped = true;
-                hasToken = true;
-                continue;
-            }
-
-            if (quote != null)
-            {
-                if (c == quote)
-                {
-                    quote = null;
-                }
-                else
-                {
-                    current.Append(c);
-                }
-
-                hasToken = true;
-                continue;
-            }
-
-            switch (c)
-            {
-                case '"':
-                case '\'':
-                    quote = c;
-                    hasToken = true;
-                    break;
-                case var _ when char.IsWhiteSpace(c):
-                    if (hasToken)
-                    {
-                        tokens.Add(current.ToString());
-                        current.Clear();
-                        hasToken = false;
-                    }
-                    break;
-                default:
-                    current.Append(c);
-                    hasToken = true;
-                    break;
-            }
-        }
-
-        if (escaped || quote != null)
-            throw new FormatException("Terminal start arguments contain an incomplete escape or quoted value.");
-
-        if (hasToken) tokens.Add(current.ToString());
-
-        return tokens;
     }
 }

--- a/src/OneWare.Terminal/ViewModels/TerminalViewModel.cs
+++ b/src/OneWare.Terminal/ViewModels/TerminalViewModel.cs
@@ -98,8 +98,33 @@ public class TerminalViewModel : ObservableObject
             {
                 var environment = BuildTerminalEnvironment(shellExecutable);
                 var startArguments = StartArguments;
+                var shellName = Path.GetFileName(shellExecutable);
+
                 if (string.IsNullOrWhiteSpace(startArguments) &&
-                    Path.GetFileName(shellExecutable).Equals("zsh", StringComparison.OrdinalIgnoreCase))
+                    shellName.Equals("bash", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Force an interactive shell and inject the completion marker through a
+                    // custom rcfile that sources the user's ~/.bashrc first. Relying only on
+                    // the PROMPT_COMMAND environment variable is unreliable because many
+                    // ~/.bashrc configurations and prompt frameworks (starship, powerline,
+                    // oh-my-bash, ...) overwrite PROMPT_COMMAND. That drops our marker, so
+                    // command-completion detection never fires and the terminal hangs until
+                    // the timeout expires.
+                    var bashRcFile = EnsureBashRcFile();
+                    if (!string.IsNullOrWhiteSpace(bashRcFile))
+                    {
+                        startArguments = $"--rcfile \"{bashRcFile}\" -i";
+                    }
+                    else
+                    {
+                        // Fallback when the rcfile cannot be written: still emit the marker via
+                        // PROMPT_COMMAND (may be overridden by user config, but better than nothing).
+                        environment = BuildBashPromptCommandEnvironment();
+                        startArguments = "-i";
+                    }
+                }
+                else if (string.IsNullOrWhiteSpace(startArguments) &&
+                         shellName.Equals("zsh", StringComparison.OrdinalIgnoreCase))
                 {
                     // Ensure zsh runs interactively so precmd hooks fire.
                     startArguments = "-i";
@@ -204,18 +229,10 @@ public class TerminalViewModel : ObservableObject
         
         if (shellName.Equals("bash", StringComparison.OrdinalIgnoreCase))
         {
-            var existingPromptCommand = Environment.GetEnvironmentVariable("PROMPT_COMMAND");
-            var markerCommand = "printf '\\033]9;OW_DONE:%s\\007' $?";
-            var combined = string.IsNullOrWhiteSpace(existingPromptCommand)
-                ? markerCommand
-                : markerCommand + ";" + existingPromptCommand;
-
-            var overrides = new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["PROMPT_COMMAND"] = combined
-            };
-
-            return BuildEnvironmentBlock(overrides);
+            // bash uses a custom rcfile (see EnsureBashRcFile) for marker injection, so no
+            // environment override is needed here. The PROMPT_COMMAND fallback lives in
+            // BuildBashPromptCommandEnvironment and is only used when the rcfile is unavailable.
+            return null;
         }
 
         if (shellName.Equals("zsh", StringComparison.OrdinalIgnoreCase))
@@ -233,7 +250,56 @@ public class TerminalViewModel : ObservableObject
 
         return null;
     }
-    
+
+    private static string? BuildBashPromptCommandEnvironment()
+    {
+        var existingPromptCommand = Environment.GetEnvironmentVariable("PROMPT_COMMAND");
+        var markerCommand = "printf '\\033]9;OW_DONE:%s\\007' $?";
+        var combined = string.IsNullOrWhiteSpace(existingPromptCommand)
+            ? markerCommand
+            : markerCommand + ";" + existingPromptCommand;
+
+        var overrides = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["PROMPT_COMMAND"] = combined
+        };
+
+        return BuildEnvironmentBlock(overrides);
+    }
+
+    private static string? EnsureBashRcFile()
+    {
+        try
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "oneware", "bash");
+            Directory.CreateDirectory(tempDir);
+
+            var rcPath = Path.Combine(tempDir, ".ow_bashrc");
+
+            var builder = new StringBuilder();
+            builder.AppendLine("# oneware bashrc");
+            // Preserve the user's interactive configuration first so their prompt,
+            // aliases and functions still apply.
+            builder.AppendLine("if [ -f \"$HOME/.bashrc\" ]; then source \"$HOME/.bashrc\"; fi");
+            // Append the completion marker AFTER sourcing the user's config so it cannot
+            // be clobbered. Prepending our hook keeps $? accurate (it runs before any
+            // pre-existing PROMPT_COMMAND can mutate the exit status). Handle both the
+            // scalar and array (bash 5.1+) forms of PROMPT_COMMAND.
+            builder.AppendLine("__ow_precmd() { printf '\\033]9;OW_DONE:%s\\007' \"$?\"; }");
+            builder.AppendLine("case \"$(declare -p PROMPT_COMMAND 2>/dev/null)\" in");
+            builder.AppendLine("  \"declare -a\"*) PROMPT_COMMAND=(__ow_precmd \"${PROMPT_COMMAND[@]}\") ;;");
+            builder.AppendLine("  *) PROMPT_COMMAND=\"__ow_precmd${PROMPT_COMMAND:+;$PROMPT_COMMAND}\" ;;");
+            builder.AppendLine("esac");
+
+            File.WriteAllText(rcPath, builder.ToString(), Encoding.ASCII);
+            return rcPath;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     private static string? EnsureZshDotDir()
     {
         try

--- a/src/OneWare.Terminal/ViewModels/TerminalViewModel.cs
+++ b/src/OneWare.Terminal/ViewModels/TerminalViewModel.cs
@@ -98,33 +98,8 @@ public class TerminalViewModel : ObservableObject
             {
                 var environment = BuildTerminalEnvironment(shellExecutable);
                 var startArguments = StartArguments;
-                var shellName = Path.GetFileName(shellExecutable);
-
                 if (string.IsNullOrWhiteSpace(startArguments) &&
-                    shellName.Equals("bash", StringComparison.OrdinalIgnoreCase))
-                {
-                    // Force an interactive shell and inject the completion marker through a
-                    // custom rcfile that sources the user's ~/.bashrc first. Relying only on
-                    // the PROMPT_COMMAND environment variable is unreliable because many
-                    // ~/.bashrc configurations and prompt frameworks (starship, powerline,
-                    // oh-my-bash, ...) overwrite PROMPT_COMMAND. That drops our marker, so
-                    // command-completion detection never fires and the terminal hangs until
-                    // the timeout expires.
-                    var bashRcFile = EnsureBashRcFile();
-                    if (!string.IsNullOrWhiteSpace(bashRcFile))
-                    {
-                        startArguments = $"--rcfile \"{bashRcFile}\" -i";
-                    }
-                    else
-                    {
-                        // Fallback when the rcfile cannot be written: still emit the marker via
-                        // PROMPT_COMMAND (may be overridden by user config, but better than nothing).
-                        environment = BuildBashPromptCommandEnvironment();
-                        startArguments = "-i";
-                    }
-                }
-                else if (string.IsNullOrWhiteSpace(startArguments) &&
-                         shellName.Equals("zsh", StringComparison.OrdinalIgnoreCase))
+                    Path.GetFileName(shellExecutable).Equals("zsh", StringComparison.OrdinalIgnoreCase))
                 {
                     // Ensure zsh runs interactively so precmd hooks fire.
                     startArguments = "-i";
@@ -229,10 +204,18 @@ public class TerminalViewModel : ObservableObject
         
         if (shellName.Equals("bash", StringComparison.OrdinalIgnoreCase))
         {
-            // bash uses a custom rcfile (see EnsureBashRcFile) for marker injection, so no
-            // environment override is needed here. The PROMPT_COMMAND fallback lives in
-            // BuildBashPromptCommandEnvironment and is only used when the rcfile is unavailable.
-            return null;
+            var existingPromptCommand = Environment.GetEnvironmentVariable("PROMPT_COMMAND");
+            var markerCommand = "printf '\\033]9;OW_DONE:%s\\007' $?";
+            var combined = string.IsNullOrWhiteSpace(existingPromptCommand)
+                ? markerCommand
+                : markerCommand + ";" + existingPromptCommand;
+
+            var overrides = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["PROMPT_COMMAND"] = combined
+            };
+
+            return BuildEnvironmentBlock(overrides);
         }
 
         if (shellName.Equals("zsh", StringComparison.OrdinalIgnoreCase))
@@ -249,55 +232,6 @@ public class TerminalViewModel : ObservableObject
         }
 
         return null;
-    }
-
-    private static string? BuildBashPromptCommandEnvironment()
-    {
-        var existingPromptCommand = Environment.GetEnvironmentVariable("PROMPT_COMMAND");
-        var markerCommand = "printf '\\033]9;OW_DONE:%s\\007' $?";
-        var combined = string.IsNullOrWhiteSpace(existingPromptCommand)
-            ? markerCommand
-            : markerCommand + ";" + existingPromptCommand;
-
-        var overrides = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            ["PROMPT_COMMAND"] = combined
-        };
-
-        return BuildEnvironmentBlock(overrides);
-    }
-
-    private static string? EnsureBashRcFile()
-    {
-        try
-        {
-            var tempDir = Path.Combine(Path.GetTempPath(), "oneware", "bash");
-            Directory.CreateDirectory(tempDir);
-
-            var rcPath = Path.Combine(tempDir, ".ow_bashrc");
-
-            var builder = new StringBuilder();
-            builder.AppendLine("# oneware bashrc");
-            // Preserve the user's interactive configuration first so their prompt,
-            // aliases and functions still apply.
-            builder.AppendLine("if [ -f \"$HOME/.bashrc\" ]; then source \"$HOME/.bashrc\"; fi");
-            // Append the completion marker AFTER sourcing the user's config so it cannot
-            // be clobbered. Prepending our hook keeps $? accurate (it runs before any
-            // pre-existing PROMPT_COMMAND can mutate the exit status). Handle both the
-            // scalar and array (bash 5.1+) forms of PROMPT_COMMAND.
-            builder.AppendLine("__ow_precmd() { printf '\\033]9;OW_DONE:%s\\007' \"$?\"; }");
-            builder.AppendLine("case \"$(declare -p PROMPT_COMMAND 2>/dev/null)\" in");
-            builder.AppendLine("  \"declare -a\"*) PROMPT_COMMAND=(__ow_precmd \"${PROMPT_COMMAND[@]}\") ;;");
-            builder.AppendLine("  *) PROMPT_COMMAND=\"__ow_precmd${PROMPT_COMMAND:+;$PROMPT_COMMAND}\" ;;");
-            builder.AppendLine("esac");
-
-            File.WriteAllText(rcPath, builder.ToString(), Encoding.ASCII);
-            return rcPath;
-        }
-        catch
-        {
-            return null;
-        }
     }
 
     private static string? EnsureZshDotDir()

--- a/src/OneWare.TerminalManager/ViewModels/TerminalManagerViewModel.cs
+++ b/src/OneWare.TerminalManager/ViewModels/TerminalManagerViewModel.cs
@@ -18,7 +18,14 @@ public class TerminalManagerViewModel : ExtendedTool, ITerminalManagerService
 {
     public const string IconKey = "Material.Console";
     private const string PromptMarkerPrefix = "\u001b]9;OW_DONE:";
-    private readonly Dictionary<string, TerminalTabModel> _automationTerminals = new(StringComparer.Ordinal);
+
+    // Automation terminals are pooled per id so that concurrent commands (e.g. an AI agent
+    // running several shell commands at once) each get their own terminal tab instead of
+    // interleaving on a single shell. Idle terminals in a pool are reused for sequential
+    // commands so shell state (working directory, environment, ...) is preserved.
+    private readonly object _automationLock = new();
+    private readonly Dictionary<string, List<TerminalTabModel>> _automationPools = new(StringComparer.Ordinal);
+    private readonly HashSet<TerminalViewModel> _busyAutomationTerminals = new();
     private readonly IMainDockService _mainDockService;
     private readonly IPaths _paths;
 
@@ -67,7 +74,7 @@ public class TerminalManagerViewModel : ExtendedTool, ITerminalManagerService
     public void CloseTab(TerminalTabModel tab)
     {
         Terminals.Remove(tab);
-        RemoveAutomationMapping(tab);
+        RemoveAutomationTerminal(tab);
 
         if (!Terminals.Any())
         {
@@ -98,7 +105,8 @@ public class TerminalManagerViewModel : ExtendedTool, ITerminalManagerService
     }
 
     public async Task<TerminalExecutionResult> ExecuteInTerminalAsync(TerminalViewModel terminal, string command,
-        TimeSpan? timeout = null, bool closeWhenDone = true, CancellationToken cancellationToken = default)
+        TimeSpan? timeout = null, bool closeWhenDone = true, IProgress<string>? outputProgress = null,
+        CancellationToken cancellationToken = default)
     {
         var readyTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -134,31 +142,86 @@ public class TerminalManagerViewModel : ExtendedTool, ITerminalManagerService
         }
 
         var output = new StringBuilder();
+        var outputLock = new object();
         var resultTcs = new TaskCompletionSource<TerminalExecutionResult>(TaskCreationOptions.RunContinuationsAsynchronously);
         var commandSent = false;
+        var markerPrefix = PromptMarkerPrefix;
+        var commandToSend = command;
+        string? markerCommand = null;
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var executionId = Guid.NewGuid().ToString("N");
+            markerPrefix = $"{PromptMarkerPrefix}{executionId}:";
+
+            // Do not depend on PROMPT_COMMAND/precmd for automation completion. User shell
+            // configuration can replace those hooks, leaving the shell visibly idle while the
+            // caller waits forever. Appending a per-command marker also prevents startup or
+            // unrelated prompt markers from completing the wrong invocation.
+            markerCommand =
+                $"__ow_exit=$?; printf '\\r\\033[2K\\033]9;OW_DONE:{executionId}:%s\\007' \"$__ow_exit\"";
+            commandToSend = $"{command}\n{markerCommand}";
+        }
+
+        void OnConnectionClosed(object? sender, EventArgs args)
+        {
+            string partialOutput;
+            lock (outputLock)
+                partialOutput = output.ToString();
+
+            resultTcs.TrySetResult(new TerminalExecutionResult(partialOutput, -1, true));
+        }
 
         void OnDataReceived(object? sender, VtNetCore.Avalonia.DataReceivedEventArgs args)
         {
             var text = Encoding.UTF8.GetString(args.Data);
-            output.Append(text);
+            string current;
+            int? completedExitCode = null;
 
-            var current = output.ToString();
-            while (TryExtractOscMarker(current, PromptMarkerPrefix, out var exitCode, out var cleaned))
+            lock (outputLock)
             {
-                current = cleaned;
-                output.Clear();
-                output.Append(cleaned);
+                output.Append(text);
+                current = output.ToString();
 
-                if (!commandSent) continue;
+                while (TryExtractOscMarker(current, markerPrefix, out var exitCode, out var cleaned))
+                {
+                    while (TryExtractOscMarker(cleaned, PromptMarkerPrefix, out _, out var promptCleaned))
+                        cleaned = promptCleaned;
 
-                resultTcs.TrySetResult(new TerminalExecutionResult(cleaned, exitCode, false));
-                break;
+                    current = cleaned;
+                    output.Clear();
+                    output.Append(cleaned);
+
+                    if (!commandSent) continue;
+
+                    completedExitCode = exitCode;
+                    break;
+                }
             }
+
+            if (completedExitCode is { } exitCodeResult)
+            {
+                outputProgress?.Report(current);
+                resultTcs.TrySetResult(new TerminalExecutionResult(current, exitCodeResult, false));
+                return;
+            }
+
+            if (commandSent && !resultTcs.Task.IsCompleted)
+                outputProgress?.Report(current);
         }
 
         terminal.Connection.DataReceived += OnDataReceived;
+        terminal.Connection.Closed += OnConnectionClosed;
+        if (markerCommand != null)
+        {
+            // The shell echoes queued input before executing it. Hide the internal marker
+            // command (including its newline) from the terminal view; its leading CR + EL
+            // then clears the intermediate prompt before the final prompt is rendered.
+            terminal.SuppressEcho(Encoding.UTF8.GetBytes($"{markerCommand}\r\n"));
+        }
+
         commandSent = true;
-        terminal.Send(command);
+        terminal.Send(commandToSend);
 
         TerminalExecutionResult result;
 
@@ -168,7 +231,10 @@ public class TerminalManagerViewModel : ExtendedTool, ITerminalManagerService
         }
         catch (OperationCanceledException)
         {
-            var partialOutput = output.ToString();
+            string partialOutput;
+            lock (outputLock)
+                partialOutput = output.ToString();
+
             // The command exceeded its timeout or was cancelled but is still running
             // in the shell. First try a gentle interrupt (Ctrl+C) so the shell returns
             // to a usable prompt and the terminal stays reusable.
@@ -187,6 +253,7 @@ public class TerminalManagerViewModel : ExtendedTool, ITerminalManagerService
         finally
         {
             terminal.Connection.DataReceived -= OnDataReceived;
+            terminal.Connection.Closed -= OnConnectionClosed;
             if (closeWhenDone) terminal.Close();
         }
 
@@ -299,36 +366,76 @@ public class TerminalManagerViewModel : ExtendedTool, ITerminalManagerService
         return true;
     }
 
-    public Task<TerminalExecutionResult> ExecuteInTerminalAsync(string command, string id,
+    public async Task<TerminalExecutionResult> ExecuteInTerminalAsync(string command, string id,
         string? workingDirectory = null, bool showInUi = false, TimeSpan? timeout = null,
-        CancellationToken cancellationToken = default)
+        IProgress<string>? outputProgress = null, CancellationToken cancellationToken = default)
     {
         _mainDockService.Show<ITerminalManagerService>();
-        
-        var tab = GetOrCreateAutomationTab(id, workingDirectory, showInUi, id);
-        return ExecuteInTerminalAsync(tab.Terminal, command, timeout, closeWhenDone: false, cancellationToken);
-    }
 
-    private TerminalTabModel GetOrCreateAutomationTab(string terminalId, string? workingDirectory, bool select,
-        string? name)
-    {
-        if (_automationTerminals.TryGetValue(terminalId, out var existing))
+        var tab = AcquireAutomationTab(id, workingDirectory, showInUi);
+        try
         {
-            if (select) SelectedTerminalTab = existing;
-            return existing;
+            return await ExecuteInTerminalAsync(tab.Terminal, command, timeout, closeWhenDone: false, outputProgress,
+                cancellationToken);
         }
-
-        var tab = NewTerminal(string.IsNullOrWhiteSpace(name) ? terminalId : name, workingDirectory, select);
-        _automationTerminals[terminalId] = tab;
-        return tab;
+        finally
+        {
+            ReleaseAutomationTab(tab);
+        }
     }
 
-    private void RemoveAutomationMapping(TerminalTabModel tab)
+    [Obsolete("Use the overload that accepts an IProgress<string> outputProgress parameter. " +
+              "This overload is kept for plugin binary compatibility and will be removed in a future release.")]
+    public Task<TerminalExecutionResult> ExecuteInTerminalAsync(string command, string id,
+        string? workingDirectory, bool showInUi, TimeSpan? timeout, CancellationToken cancellationToken)
     {
-        var mapping = _automationTerminals.FirstOrDefault(entry => ReferenceEquals(entry.Value, tab));
-        if (!string.IsNullOrEmpty(mapping.Key))
+        return ExecuteInTerminalAsync(command, id, workingDirectory, showInUi, timeout, null, cancellationToken);
+    }
+
+    private TerminalTabModel AcquireAutomationTab(string id, string? workingDirectory, bool select)
+    {
+        lock (_automationLock)
         {
-            _automationTerminals.Remove(mapping.Key);
+            if (!_automationPools.TryGetValue(id, out var pool))
+            {
+                pool = new List<TerminalTabModel>();
+                _automationPools[id] = pool;
+            }
+
+            // Reuse an idle terminal from the pool so sequential commands keep their shell state.
+            var idle = pool.FirstOrDefault(t => !_busyAutomationTerminals.Contains(t.Terminal));
+            if (idle != null)
+            {
+                _busyAutomationTerminals.Add(idle.Terminal);
+                if (select) SelectedTerminalTab = idle;
+                return idle;
+            }
+
+            // Every pooled terminal is currently busy (or none exist yet): open another tab so
+            // concurrent commands run side by side instead of colliding on one shell.
+            var tab = NewTerminal(id, workingDirectory, select);
+            pool.Add(tab);
+            _busyAutomationTerminals.Add(tab.Terminal);
+            return tab;
+        }
+    }
+
+    private void ReleaseAutomationTab(TerminalTabModel tab)
+    {
+        lock (_automationLock)
+        {
+            _busyAutomationTerminals.Remove(tab.Terminal);
+        }
+    }
+
+    private void RemoveAutomationTerminal(TerminalTabModel tab)
+    {
+        lock (_automationLock)
+        {
+            _busyAutomationTerminals.Remove(tab.Terminal);
+
+            foreach (var pool in _automationPools.Values)
+                pool.Remove(tab);
         }
     }
 

--- a/src/OneWare.TerminalManager/ViewModels/TerminalManagerViewModel.cs
+++ b/src/OneWare.TerminalManager/ViewModels/TerminalManagerViewModel.cs
@@ -159,7 +159,7 @@ public class TerminalManagerViewModel : ExtendedTool, ITerminalManagerService
             // caller waits forever. Appending a per-command marker also prevents startup or
             // unrelated prompt markers from completing the wrong invocation.
             markerCommand =
-                $"__ow_exit=$?; printf '\\r\\033[2K\\033]9;OW_DONE:{executionId}:%s\\007' \"$__ow_exit\"";
+                $"__ow_exit=$?; printf '\\033[1A\\r\\033[2K\\033]9;OW_DONE:{executionId}:%s\\007' \"$__ow_exit\"";
             commandToSend = $"{command}\n{markerCommand}";
         }
 
@@ -215,9 +215,9 @@ public class TerminalManagerViewModel : ExtendedTool, ITerminalManagerService
         if (markerCommand != null)
         {
             // The shell echoes queued input before executing it. Hide the internal marker
-            // command (including its newline) from the terminal view; its leading CR + EL
-            // then clears the intermediate prompt before the final prompt is rendered.
-            terminal.SuppressEcho(Encoding.UTF8.GetBytes($"{markerCommand}\r\n"));
+            // command independently of the PTY's line-ending mode. The marker then moves back
+            // and clears the intermediate prompt before the final prompt is rendered.
+            terminal.SuppressEcho(Encoding.UTF8.GetBytes(markerCommand));
         }
 
         commandSent = true;


### PR DESCRIPTION
## Summary
- stream invocation-scoped tool output into AI chat while supporting concurrent tool calls
- pool AI terminal tabs so parallel commands run independently and preserve sequential shell state
- harden Linux PTY startup, command completion, cancellation, and shell-exit handling
- preserve terminal service and AI function provider plugin compatibility
- restore project-root index paths when persisting explorer state

## Validation
- `dotnet build OneWare.slnx -v minimal`
- `dotnet test OneWare.slnx --no-build -v minimal`