### PR TITLE
[WIP] Update ONNX Runtime packages to 1.28.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <OnnxRuntimeVersion>1.23.2</OnnxRuntimeVersion>
+    <OnnxRuntimeVersion>1.28.0</OnnxRuntimeVersion>
   </PropertyGroup>
 </Project>

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -161,8 +161,8 @@ COMPONENTS UNDER THE MIT LICENSE
   - Microsoft.IdentityModel.JsonWebTokens 8.15.0
   - Microsoft.IdentityModel.Logging 8.15.0
   - Microsoft.IdentityModel.Tokens 8.15.0
-  - Microsoft.ML.OnnxRuntime 1.23.2
-  - Microsoft.ML.OnnxRuntime.Managed 1.23.2
+  - Microsoft.ML.OnnxRuntime 1.28.0
+  - Microsoft.ML.OnnxRuntime.Managed 1.28.0
   - Microsoft.NET.ILLink.Tasks 10.0.7
   - Microsoft.NET.Sdk.WebAssembly.Pack 10.0.7
   - Microsoft.NET.StringTools 18.0.2

--- a/src/OneWare.PackageManager/Installers/OnnxRuntimePackageInstaller.cs
+++ b/src/OneWare.PackageManager/Installers/OnnxRuntimePackageInstaller.cs
@@ -25,9 +25,6 @@ public class OnnxRuntimePackageInstaller : PackageInstallerBase
         var recommendedExecutionProvider = runtime switch
         {
             "onnxruntime-nvidia" => OnnxExecutionProvider.Cuda,
-            "onnxruntime-directml" => OnnxExecutionProvider.DirectMl,
-            "onnxruntime-openvino" => OnnxExecutionProvider.OpenVino,
-            "onnxruntime-qnn" => OnnxExecutionProvider.Qnn,
             _ => OnnxExecutionProvider.Cpu
         };
         settingsService.SetSettingValue("OnnxRuntime_SelectedExecutionProvider", recommendedExecutionProvider);

--- a/src/OneWare.PackageManager/PackageManagerModule.cs
+++ b/src/OneWare.PackageManager/PackageManagerModule.cs
@@ -47,155 +47,19 @@ public class PackageManagerModule : OneWareModuleBase
         [
             new PackageVersion
             {
-                Version = "1.23.2",
+                Version = "1.28.0",
                 Targets =
                 [
                     new PackageTarget
                     {
                         Target = "linux-x64",
-                        Url = "https://www.nuget.org/api/v2/package/Microsoft.ML.OnnxRuntime.Gpu.Linux/1.23.2"
+                        Url = "https://www.nuget.org/api/v2/package/Microsoft.ML.OnnxRuntime.Gpu.Linux/1.28.0"
                     },
                     new PackageTarget
                     {
                         Target = "win-x64",
-                        Url = "https://www.nuget.org/api/v2/package/Microsoft.ML.OnnxRuntime.Gpu.Windows/1.23.2"
+                        Url = "https://www.nuget.org/api/v2/package/Microsoft.ML.OnnxRuntime.Gpu.Windows/1.28.0"
                     },
-                ]
-            }
-        ]
-    };
-
-    public static readonly Package OnnxRuntimeDirectMlPackage = new()
-    {
-        Category = "ONNX Runtimes",
-        Id = "onnxruntime-directml",
-        Type = "OnnxRuntime",
-        Name = "ONNX Runtime DirectML",
-        Description = "ONNX Runtime with DirectML for Windows",
-        License = "MIT",
-        IconUrl = "https://raw.githubusercontent.com/hendrikmennen/SAM3-TENSORRT-PYTHON/refs/heads/main/ORT_icon_for_light_bg.png",
-        Links =
-        [
-            new PackageLink
-            {
-                Name = "NuGet",
-                Url = "https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime.DirectML/1.23.0"
-            },
-            new PackageLink
-            {
-                Name = "GitHub",
-                Url = "https://github.com/microsoft/onnxruntime"
-            }
-        ],
-        Tabs =
-        [
-            new PackageTab
-            {
-                Title = "License",
-                ContentUrl = "https://raw.githubusercontent.com/microsoft/onnxruntime/main/LICENSE"
-            }
-        ],
-        Versions =
-        [
-            new PackageVersion
-            {
-                Version = "1.23.0",
-                Targets =
-                [
-                    new PackageTarget
-                    {
-                        Target = "win-x64",
-                        Url = "https://www.nuget.org/api/v2/package/Microsoft.ML.OnnxRuntime.DirectML/1.23.0"
-                    },
-                    new PackageTarget
-                    {
-                        Target = "win-arm64",
-                        Url = "https://www.nuget.org/api/v2/package/Microsoft.ML.OnnxRuntime.DirectML/1.23.0"
-                    }
-                ]
-            }
-        ]
-    };
-
-    public static readonly Package OnnxRuntimeOpenVinoPackage = new()
-    {
-        Category = "ONNX Runtimes",
-        Id = "onnxruntime-openvino",
-        Type = "OnnxRuntime",
-        Name = "ONNX Runtime OpenVINO",
-        Description = "ONNX Runtime with OpenVINO execution provider",
-        License = "MIT",
-        IconUrl = "https://raw.githubusercontent.com/hendrikmennen/SAM3-TENSORRT-PYTHON/refs/heads/main/ORT_icon_for_light_bg.png",
-        Links =
-        [
-            new PackageLink
-            {
-                Name = "GitHub",
-                Url = "https://github.com/microsoft/onnxruntime"
-            }
-        ],
-        Tabs =
-        [
-            new PackageTab
-            {
-                Title = "License",
-                ContentUrl = "https://raw.githubusercontent.com/microsoft/onnxruntime/main/LICENSE"
-            }
-        ],
-        Versions =
-        [
-            new PackageVersion
-            {
-                Version = "1.23.0",
-                Targets =
-                [
-                    new PackageTarget
-                    {
-                        Target = "win-x64",
-                        Url = "https://www.nuget.org/api/v2/package/Intel.ML.OnnxRuntime.OpenVino/1.23.0"
-                    }
-                ]
-            }
-        ]
-    };
-
-    public static readonly Package OnnxRuntimeQnnPackage = new()
-    {
-        Category = "ONNX Runtimes",
-        Id = "onnxruntime-qnn",
-        Type = "OnnxRuntime",
-        Name = "ONNX Runtime QNN",
-        Description = "ONNX Runtime with Qualcomm QNN execution provider",
-        License = "MIT",
-        IconUrl = "https://raw.githubusercontent.com/hendrikmennen/SAM3-TENSORRT-PYTHON/refs/heads/main/ORT_icon_for_light_bg.png",
-        Links =
-        [
-            new PackageLink
-            {
-                Name = "GitHub",
-                Url = "https://github.com/microsoft/onnxruntime"
-            }
-        ],
-        Tabs =
-        [
-            new PackageTab
-            {
-                Title = "License",
-                ContentUrl = "https://raw.githubusercontent.com/microsoft/onnxruntime/main/LICENSE"
-            }
-        ],
-        Versions =
-        [
-            new PackageVersion
-            {
-                Version = "1.23.2",
-                Targets =
-                [
-                    new PackageTarget
-                    {
-                        Target = "win-arm64",
-                        Url = "https://www.nuget.org/api/v2/package/Microsoft.ML.OnnxRuntime.QNN/1.23.2"
-                    }
                 ]
             }
         ]
@@ -206,6 +70,7 @@ public class PackageManagerModule : OneWareModuleBase
         services.AddSingleton<IPackageRepositoryClient, PackageRepositoryClient>();
         services.AddSingleton<IPackageCatalog, PackageCatalog>();
         services.AddSingleton<IPackageStateStore, PackageStateStore>();
+        services.AddSingleton<OnnxRuntimePackageMigration>();
         services.AddSingleton<IPackageDownloader, PackageDownloader>();
         services.AddSingleton<PluginPackageInstaller>();
         services.AddSingleton<NativeToolPackageInstaller>();
@@ -221,6 +86,8 @@ public class PackageManagerModule : OneWareModuleBase
 
     public override void Initialize(IServiceProvider serviceProvider)
     {
+        serviceProvider.Resolve<OnnxRuntimePackageMigration>().Start();
+
         var packageService = serviceProvider.Resolve<IPackageService>();
         packageService.RegisterInstaller<PluginPackageInstaller>("Plugin");
         packageService.RegisterInstaller<NativeToolPackageInstaller>("NativeTool");
@@ -230,15 +97,6 @@ public class PackageManagerModule : OneWareModuleBase
 
         if(PlatformHelper.Platform is PlatformId.LinuxX64 or PlatformId.WinX64)
             packageService.RegisterPackage(OnnxRuntimeNvidiaPackage);
-        
-        if(PlatformHelper.Platform is PlatformId.WinX64 or PlatformId.WinArm64)
-            packageService.RegisterPackage(OnnxRuntimeDirectMlPackage);
-        
-        if(PlatformHelper.Platform is PlatformId.WinX64)
-            packageService.RegisterPackage(OnnxRuntimeOpenVinoPackage);
-        
-        if(PlatformHelper.Platform is PlatformId.WinArm64)
-            packageService.RegisterPackage(OnnxRuntimeQnnPackage);
 
         var windowService = serviceProvider.Resolve<IWindowService>();
 

--- a/src/OneWare.PackageManager/Services/OnnxRuntimePackageMigration.cs
+++ b/src/OneWare.PackageManager/Services/OnnxRuntimePackageMigration.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Logging;
+using OneWare.Essentials.Enums;
+using OneWare.Essentials.PackageManager;
+using OneWare.Essentials.Services;
+
+namespace OneWare.PackageManager.Services;
+
+public class OnnxRuntimePackageMigration(
+    IPackageStateStore stateStore,
+    IPaths paths,
+    ISettingsService settingsService,
+    ILogger logger)
+{
+    private readonly object _migrationLock = new();
+    private Task? _migrationTask;
+
+    private const string SelectedRuntimeSettingKey = "OnnxRuntime_SelectedRuntime";
+    private const string SelectedExecutionProviderSettingKey = "OnnxRuntime_SelectedExecutionProvider";
+
+    private const string CurrentPackageId = "onnxruntime-nvidia";
+    private const string CurrentVersion = "1.28.0";
+
+    private static readonly string[] RetiredPackageIds =
+    [
+        "onnxruntime-directml",
+        "onnxruntime-openvino",
+        "onnxruntime-qnn"
+    ];
+
+    public void Start()
+    {
+        _ = ObserveMigrationAsync();
+    }
+
+    public Task MigrateAsync()
+    {
+        lock (_migrationLock)
+            return _migrationTask ??= MigrateInternalAsync();
+    }
+
+    private async Task MigrateInternalAsync()
+    {
+        var installed = await stateStore.LoadAsync();
+        var retained = new Dictionary<string, InstalledPackage>(installed);
+        var removedPackageIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var package in installed.Values.Where(IsOutdated))
+        {
+            if (!TryDeletePackageDirectory(package.Id)) continue;
+
+            retained.Remove(package.Id);
+            removedPackageIds.Add(package.Id);
+        }
+
+        foreach (var packageId in RetiredPackageIds.Where(id => !installed.ContainsKey(id)))
+        {
+            if (TryDeletePackageDirectory(packageId))
+                removedPackageIds.Add(packageId);
+        }
+
+        if (retained.Count != installed.Count)
+            await stateStore.SaveAsync(retained.Values);
+
+        var selectedRuntime = settingsService.GetSettingValue<string>(SelectedRuntimeSettingKey);
+        if (selectedRuntime == null || !removedPackageIds.Contains(selectedRuntime)) return;
+
+        settingsService.SetSettingValue(SelectedRuntimeSettingKey, "onnxruntime-builtin");
+        settingsService.SetSettingValue(SelectedExecutionProviderSettingKey, OnnxExecutionProvider.Cpu);
+        settingsService.Save(paths.SettingsPath);
+    }
+
+    private async Task ObserveMigrationAsync()
+    {
+        try
+        {
+            await MigrateAsync();
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Failed to migrate outdated ONNX Runtime packages.");
+        }
+    }
+
+    private static bool IsOutdated(InstalledPackage package)
+    {
+        if (!string.Equals(package.Type, "OnnxRuntime", StringComparison.OrdinalIgnoreCase)) return false;
+
+        return !string.Equals(package.Id, CurrentPackageId, StringComparison.OrdinalIgnoreCase)
+               || !string.Equals(package.InstalledVersion, CurrentVersion, StringComparison.Ordinal);
+    }
+
+    private bool TryDeletePackageDirectory(string packageId)
+    {
+        var packageDirectory = Path.Combine(paths.OnnxRuntimesDirectory, packageId);
+        if (!Directory.Exists(packageDirectory)) return true;
+
+        try
+        {
+            Directory.Delete(packageDirectory, true);
+            logger.LogInformation("Removed outdated ONNX Runtime package '{PackageId}'.", packageId);
+            return true;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            logger.LogWarning(exception, "Failed to remove outdated ONNX Runtime package '{PackageId}'.", packageId);
+            return false;
+        }
+    }
+}

--- a/src/OneWare.PackageManager/Services/PackageService.cs
+++ b/src/OneWare.PackageManager/Services/PackageService.cs
@@ -29,6 +29,7 @@ public class PackageService : ObservableObject, IPackageService
     private readonly ISettingsService _settingsService;
     private readonly IApplicationStateService _applicationStateService;
     private readonly IPackageStateStore _stateStore;
+    private readonly OnnxRuntimePackageMigration _onnxRuntimePackageMigration;
     private readonly IPackageInstaller _defaultInstaller;
     private readonly IPaths _paths;
     private readonly Dictionary<string, Type> _installersByType = new(StringComparer.OrdinalIgnoreCase);
@@ -40,11 +41,13 @@ public class PackageService : ObservableObject, IPackageService
 
     public PackageService(IPackageCatalog catalog, IPackageDownloader downloader, IPackageStateStore stateStore,
         ISettingsService settingsService, ILogger logger, IApplicationStateService applicationStateService,
-        IHttpService httpService, IPaths paths, ICompositeServiceProvider compositeServiceProvider, GenericPackageInstaller genericPackageInstaller)
+        IHttpService httpService, IPaths paths, ICompositeServiceProvider compositeServiceProvider,
+        GenericPackageInstaller genericPackageInstaller, OnnxRuntimePackageMigration onnxRuntimePackageMigration)
     {
         _catalog = catalog;
         _downloader = downloader;
         _stateStore = stateStore;
+        _onnxRuntimePackageMigration = onnxRuntimePackageMigration;
         _settingsService = settingsService;
         _logger = logger;
         _applicationStateService = applicationStateService;
@@ -364,6 +367,7 @@ public class PackageService : ObservableObject, IPackageService
     private async Task<bool> RefreshInternalAsync()
     {
         await WaitForInstallsAsync();
+        await _onnxRuntimePackageMigration.MigrateAsync();
 
         IsUpdating = true;
         var result = true;

--- a/tests/OneWare.PackageManager.UnitTests/OnnxRuntimePackageMigrationTests.cs
+++ b/tests/OneWare.PackageManager.UnitTests/OnnxRuntimePackageMigrationTests.cs
@@ -1,0 +1,92 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using OneWare.Essentials.Enums;
+using OneWare.Essentials.PackageManager;
+using OneWare.Essentials.Services;
+using OneWare.PackageManager.Services;
+using Xunit;
+
+namespace OneWare.PackageManager.UnitTests;
+
+public class OnnxRuntimePackageMigrationTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"onnx-migration-{Guid.NewGuid()}");
+    private readonly IPackageStateStore _stateStore = Substitute.For<IPackageStateStore>();
+    private readonly IPaths _paths = Substitute.For<IPaths>();
+    private readonly ISettingsService _settingsService = Substitute.For<ISettingsService>();
+    private readonly ILogger<OnnxRuntimePackageMigration> _logger =
+        Substitute.For<ILogger<OnnxRuntimePackageMigration>>();
+
+    public OnnxRuntimePackageMigrationTests()
+    {
+        _paths.OnnxRuntimesDirectory.Returns(Path.Combine(_root, "runtimes"));
+        _paths.SettingsPath.Returns(Path.Combine(_root, "settings.json"));
+    }
+
+    [Fact]
+    public async Task MigrateAsync_RemovesOutdatedAndRetiredRuntimes()
+    {
+        var oldNvidia = RuntimePackage("onnxruntime-nvidia", "1.23.2");
+        var retiredQnn = RuntimePackage("onnxruntime-qnn", "1.23.2");
+        var plugin = new InstalledPackage("plugin", "Plugin", "Plugin", null, null, null, "1.0.0");
+        var installed = new Dictionary<string, InstalledPackage>
+        {
+            [oldNvidia.Id] = oldNvidia,
+            [retiredQnn.Id] = retiredQnn,
+            [plugin.Id] = plugin
+        };
+
+        _stateStore.LoadAsync(Arg.Any<CancellationToken>()).Returns(installed);
+        _settingsService.GetSettingValue<string>("OnnxRuntime_SelectedRuntime").Returns(retiredQnn.Id);
+        CreateRuntimeDirectory(oldNvidia.Id);
+        CreateRuntimeDirectory(retiredQnn.Id);
+
+        await CreateMigration().MigrateAsync();
+
+        Assert.False(Directory.Exists(Path.Combine(_paths.OnnxRuntimesDirectory, oldNvidia.Id)));
+        Assert.False(Directory.Exists(Path.Combine(_paths.OnnxRuntimesDirectory, retiredQnn.Id)));
+        await _stateStore.Received(1).SaveAsync(
+            Arg.Is<IEnumerable<InstalledPackage>>(packages =>
+                packages.Count() == 1 && packages.Single().Id == plugin.Id),
+            Arg.Any<CancellationToken>());
+        _settingsService.Received(1).SetSettingValue("OnnxRuntime_SelectedRuntime", "onnxruntime-builtin");
+        _settingsService.Received(1)
+            .SetSettingValue("OnnxRuntime_SelectedExecutionProvider", OnnxExecutionProvider.Cpu);
+        _settingsService.Received(1).Save(_paths.SettingsPath);
+    }
+
+    [Fact]
+    public async Task MigrateAsync_PreservesCurrentRuntime()
+    {
+        var current = RuntimePackage("onnxruntime-nvidia", "1.28.0");
+        _stateStore.LoadAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<string, InstalledPackage> { [current.Id] = current });
+        CreateRuntimeDirectory(current.Id);
+
+        await CreateMigration().MigrateAsync();
+
+        Assert.True(Directory.Exists(Path.Combine(_paths.OnnxRuntimesDirectory, current.Id)));
+        await _stateStore.DidNotReceive()
+            .SaveAsync(Arg.Any<IEnumerable<InstalledPackage>>(), Arg.Any<CancellationToken>());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, true);
+    }
+
+    private OnnxRuntimePackageMigration CreateMigration()
+    {
+        return new OnnxRuntimePackageMigration(_stateStore, _paths, _settingsService, _logger);
+    }
+
+    private void CreateRuntimeDirectory(string packageId)
+    {
+        Directory.CreateDirectory(Path.Combine(_paths.OnnxRuntimesDirectory, packageId));
+    }
+
+    private static InstalledPackage RuntimePackage(string id, string version)
+    {
+        return new InstalledPackage(id, "OnnxRuntime", id, "ONNX Runtimes", null, "MIT", version);
+    }
+}


### PR DESCRIPTION
## Summary
- update managed, built-in, and NVIDIA ONNX Runtime packages to 1.28.0
- remove DirectML, OpenVINO, and QNN catalog entries unavailable at 1.28.0
- remove stale runtime installations and reset affected users to the built-in CPU runtime

## Validation
- `dotnet test tests/OneWare.PackageManager.UnitTests/OneWare.PackageManager.UnitTests.csproj -v minimal`
- `dotnet build src/OneWare.Core/OneWare.Core.csproj -v minimal`