### PR TITLE
Fix ArgumentOutOfRangeException crash in Problems list

### DIFF
--- a/src/OneWare.ErrorList/BatchObservableCollection.cs
+++ b/src/OneWare.ErrorList/BatchObservableCollection.cs
@@ -1,0 +1,67 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace OneWare.ErrorList;
+
+/// <summary>
+///     ObservableCollection that can suppress change notifications while a batch of mutations is applied and
+///     raises a single Reset afterwards.
+///     This is required for <see cref="Avalonia.Collections.DataGridCollectionView" />, which crashes
+///     (ArgumentOutOfRangeException in AdjustCurrencyForRemove) when an item that is filtered out of the view is
+///     removed while the current position is 0. Handling a Reset makes the view rebuild itself safely.
+/// </summary>
+internal class BatchObservableCollection<T> : ObservableCollection<T>
+{
+    private bool _isDirty;
+    private int _suspendLevel;
+
+    public IDisposable BeginBatch()
+    {
+        _suspendLevel++;
+        return new BatchScope(this);
+    }
+
+    protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+    {
+        if (_suspendLevel > 0)
+        {
+            _isDirty = true;
+            return;
+        }
+
+        base.OnCollectionChanged(e);
+    }
+
+    protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+    {
+        if (_suspendLevel > 0) return;
+
+        base.OnPropertyChanged(e);
+    }
+
+    private void EndBatch()
+    {
+        if (_suspendLevel == 0) return;
+
+        _suspendLevel--;
+        if (_suspendLevel > 0 || !_isDirty) return;
+
+        _isDirty = false;
+        OnPropertyChanged(new PropertyChangedEventArgs(nameof(Count)));
+        OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+        OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+    }
+
+    private sealed class BatchScope(BatchObservableCollection<T> owner) : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            owner.EndBatch();
+        }
+    }
+}

--- a/src/OneWare.ErrorList/ViewModels/ErrorListViewModel.cs
+++ b/src/OneWare.ErrorList/ViewModels/ErrorListViewModel.cs
@@ -22,7 +22,7 @@ public class ErrorListViewModel : ExtendedTool, IErrorService
 {
     public const string IconKey = "MaterialDesign.ErrorOutline";
 
-    private readonly ObservableCollection<ErrorListItem> _items = new();
+    private readonly BatchObservableCollection<ErrorListItem> _items = new();
 
     private readonly IMainDockService _mainDockService;
     private readonly IProjectExplorerService _projectExplorerExplorerViewModel;
@@ -194,7 +194,11 @@ public class ErrorListViewModel : ExtendedTool, IErrorService
 
     public void ClearFile(string filePath)
     {
-        ListEx.RemoveMany(_items, _items.Where(x => x.FilePath.EqualPaths(filePath)));
+        using (_items.BeginBatch())
+        {
+            ListEx.RemoveMany(_items, _items.Where(x => x.FilePath.EqualPaths(filePath)));
+        }
+
         ErrorRefresh?.Invoke(this, filePath);
         RefreshCountToggle();
     }
@@ -204,7 +208,10 @@ public class ErrorListViewModel : ExtendedTool, IErrorService
         var errors = _items.Where(x => x.Source == source).ToList();
         var files = errors.Select(x => x.FilePath).Distinct();
 
-        ListEx.RemoveMany(_items, errors);
+        using (_items.BeginBatch())
+        {
+            ListEx.RemoveMany(_items, errors);
+        }
 
         foreach (var file in files) ErrorRefresh?.Invoke(this, file);
 
@@ -231,10 +238,13 @@ public class ErrorListViewModel : ExtendedTool, IErrorService
     /// </summary>
     public void RefreshErrors(IList<ErrorListItem> errors, string source, string filePath)
     {
-        ListEx.RemoveMany(_items,
-            _items.Where(x => x.FilePath.EqualPaths(filePath) && x.Source == source && !errors.Contains(x)));
+        using (_items.BeginBatch())
+        {
+            ListEx.RemoveMany(_items,
+                _items.Where(x => x.FilePath.EqualPaths(filePath) && x.Source == source && !errors.Contains(x)));
 
-        foreach (var e in errors) Add(e);
+            foreach (var e in errors) Add(e);
+        }
 
         ErrorRefresh?.Invoke(this, filePath);
         RefreshCountToggle();
@@ -328,15 +338,23 @@ public class ErrorListViewModel : ExtendedTool, IErrorService
 
     public void Clear(IProjectRoot project)
     {
-        ListEx.RemoveMany(_items, _items.Where(x => x.Root == project));
+        using (_items.BeginBatch())
+        {
+            ListEx.RemoveMany(_items, _items.Where(x => x.Root == project));
+        }
+
         ErrorRefresh?.Invoke(this, project);
         RefreshCountToggle();
     }
 
     public void Clear(IProjectRoot project, string source)
     {
-        ListEx.RemoveMany(_items,
-            _items.Where(x => x.Root == project && x.Source == source));
+        using (_items.BeginBatch())
+        {
+            ListEx.RemoveMany(_items,
+                _items.Where(x => x.Root == project && x.Source == source));
+        }
+
         ErrorRefresh?.Invoke(this, project);
         RefreshCountToggle();
     }


### PR DESCRIPTION
## Problem

The app crashes with:

```
System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'index')
   at Avalonia.Collections.DataGridCollectionView.GetItemAt(Int32 index)
   at Avalonia.Collections.DataGridCollectionView.get_IsCurrentInSync()
   at Avalonia.Collections.DataGridCollectionView.AdjustCurrencyForRemove(Int32 index)
   at Avalonia.Collections.DataGridCollectionView.ProcessRemoveEvent(Object removedItem, Boolean isReplace)
   at Avalonia.Collections.DataGridCollectionView.ProcessCollectionChanged(NotifyCollectionChangedEventArgs args)
   at System.Collections.ObjectModel.ObservableCollection`1.OnCollectionChanged(NotifyCollectionChangedEventArgs e)
   at OneWare.AI.UI.ViewModels.AiProjectViewModel.RefreshDiagnostics(Boolean includeExpensiveChecks)
```

## Root cause

Upstream bug in Avalonia's `DataGridCollectionView`: `ProcessRemoveEvent` does **not** check `PassesFilter` (unlike `ProcessAddEvent`).

When an item that is filtered *out* of the view is removed from the source collection:

1. `removeIndex = IndexOf(removedItem)` is `-1`
2. `needToRemove` is still `true` (`internalRemoveIndex < (PageIndex + 1) * PageSize` → `-1 < 0`)
3. `AdjustCurrencyForRemove(-1)` takes the `index < CurrentPosition` branch and does `SetCurrent(CurrentItem, CurrentPosition - 1)` → `CurrentPosition == -1` while `CurrentItem` is still in the view
4. The `CurrentPosition >= Count` guard doesn't catch a negative position
5. `IsCurrentInSync` → `IsCurrentInView` is `true` → `GetItemAt(-1)` throws

So it reproduces whenever a problem row **at position 0** is current and a **filtered-out** error is removed — exactly what `IErrorService.RefreshErrors` does during an AI project diagnostics refresh.

## Fix

Added `BatchObservableCollection<T>`, which suppresses change notifications while a batch of mutations is applied and raises a single `Reset` afterwards. `DataGridCollectionView` handles `Reset` via `RefreshOrDefer()` → `RefreshOverride()`, which rebuilds the view and restores currency through `ResetCurrencyValues`, bypassing the broken incremental-remove path entirely.

All removal paths in `ErrorListViewModel` are now batched: `RefreshErrors`, `ClearFile`, `Clear(source)`, `Clear(project)` and `Clear(project, source)`. No `Reset` is raised if the batch didn't actually change anything, so unchanged diagnostics refreshes stay free.

## Verification

Standalone repro against `Avalonia.Controls.DataGrid`:

```
before: cur=b pos=0
plain CRASH: ArgumentOutOfRangeException Specified argument was out of the range of valid values. (Parameter 'index')
batch: no crash, count=2 cur=b pos=0
```

The batched collection completes cleanly and preserves the current item/position. `dotnet build src/OneWare.ErrorList/OneWare.ErrorList.csproj` succeeds with 0 errors.