### PR TITLE
Fix URL launch action behavior

### DIFF
--- a/studio/OneWare.Studio.Desktop/Program.cs
+++ b/studio/OneWare.Studio.Desktop/Program.cs
@@ -239,7 +239,6 @@ internal abstract class Program
             }
             else if (target.StartsWith("oneware://", StringComparison.OrdinalIgnoreCase))
             {
-                Environment.SetEnvironmentVariable("ONEWARE_OPEN_URL", target);
                 logger?.Log($"Opening URL: {target}");
                 ContainerLocator.Container?.Resolve<IApplicationStateService>()
                     .ExecuteUrlLaunchActions(new Uri(target));


### PR DESCRIPTION
This pull request makes a minor change to the `HandleOpenTarget` method in `Program.cs`, removing the code that set the `ONEWARE_OPEN_URL` environment variable when opening a OneWare URL. The rest of the URL handling logic remains unchanged.

* Removed the line that set the `ONEWARE_OPEN_URL` environment variable when handling URLs starting with `oneware://` in `HandleOpenTarget` (`Program.cs`).

Fixes:

1. Startup race → double handling. The IPC server is started in Main (line 399) before StartWithClassicDesktopLifetime. If a forwarded URL arrives while the primary is still loading (package refresh does network I/O, so this window is real), line 242 sets the variable, and then App.axaml.cs:722 reads it and calls ExecuteUrlLaunchActions again for the same URI. Removing line 242 eliminates that duplicate.
Same race also non-deterministically suppresses the AiReleaseWindow via DesktopStudioApp.cs:255. After removal that becomes deterministic.

2. Stickiness across restart. This is the one tied to our earlier discussion: the variable lives for the whole process lifetime, and PerformRestart inherits the environment (ShellExecuteEx on Windows, execv on Linux/macOS). So once a oneware:// URL arrives over IPC, every subsequent restart — e.g. after a package install — re-fires that stale URL launch action at App.axaml.cs:722. Removing line 242 removes that source of staleness.