### PR TITLE
Update package status handling

### DIFF
--- a/src/OneWare.PackageManager/Services/PackageService.cs
+++ b/src/OneWare.PackageManager/Services/PackageService.cs
@@ -610,8 +610,8 @@ public class PackageService : ObservableObject, IPackageService, IDisposable
 
             state.InstalledVersion = version;
             state.InstalledVersionWarningText = result.InstalledVersionWarningText;
-            state.Status = result.Status;
             state.Progress = 0;
+            UpdateStatus(state);
 
             await SaveInstalledPackagesAsync();
 


### PR DESCRIPTION
This pull request makes a minor update to the package installation process. Instead of directly setting the `Status` of the package state from the result, it now calls the `UpdateStatus` method, likely to centralize status management logic and ensure consistency.

Closes #359. 