### PR TITLE
FPGA toolchain fixes, toolchain settings split, and an FPGA AI agent

### DIFF
--- a/src/OneWare.Core/Services/ChildProcessService.cs
+++ b/src/OneWare.Core/Services/ChildProcessService.cs
@@ -86,6 +86,7 @@ public class ChildProcessService(
             key = applicationStateService.AddState(status, state, () => tokenSource.Cancel());
 
             var start = DateTime.Now;
+            var cancelled = false;
 
             var statusTimer = showTimer
                 ? new DispatcherTimer(new TimeSpan(0, 0, 0, 1), DispatcherPriority.Default,
@@ -148,6 +149,7 @@ public class ChildProcessService(
             }
             catch (TaskCanceledException)
             {
+                cancelled = true;
                 logger.Log(
                     $"[{Path.GetFileName(workingDirectory)}]: {Path.GetFileNameWithoutExtension(path)} cancelled!",
                     true, Brushes.DarkOrange);
@@ -159,6 +161,21 @@ public class ChildProcessService(
 
             collectorTimer.Stop();
             statusTimer?.Stop();
+
+            if (cancelled)
+            {
+                success = false;
+            }
+            else
+            {
+                var exitCode = childProcess.ExitCode;
+                if (exitCode != 0)
+                {
+                    success = false;
+                    logger.Error(
+                        $"[{Path.GetFileName(workingDirectory)}]: {Path.GetFileNameWithoutExtension(path)} exited with code {exitCode}");
+                }
+            }
         }
         catch (Exception e)
         {

--- a/src/OneWare.OssCadSuiteIntegration/Loaders/OpenFpgaLoader.cs
+++ b/src/OneWare.OssCadSuiteIntegration/Loaders/OpenFpgaLoader.cs
@@ -58,9 +58,24 @@ public class OpenFpgaLoader(ISettingsService settingsService, ILogger logger, IO
         
         outputService.WriteLine("Starting OpenFpgaLoader ...");
         
+        var bitstreamPath = BitstreamPaths.GetValueOrDefault(bitstreamFormat);
+        if (bitstreamPath != null && !File.Exists(Path.Combine(project.FullPath, bitstreamPath)))
+        {
+            logger.Error($"Bitstream '{bitstreamPath}' not found. Compile the project successfully first.");
+            return;
+        }
+
         try 
         {
-            await toolExecutionDispatcherService.ExecuteAsync(command);
+            var (success, _) = await toolExecutionDispatcherService.ExecuteAsync(command);
+
+            if (!success)
+            {
+                logger.Error("OpenFpgaLoader failed. See output for details.");
+                return;
+            }
+
+            Dispatcher.UIThread.Post(() => { outputService.WriteLine("OpenFpgaLoader finished successfully"); });
         }
         catch (Exception ex)
         {

--- a/src/OneWare.OssCadSuiteIntegration/OneWare.OssCadSuiteIntegration.csproj
+++ b/src/OneWare.OssCadSuiteIntegration/OneWare.OssCadSuiteIntegration.csproj
@@ -11,4 +11,10 @@
         <ProjectReference Include="..\OneWare.ToolEngine\OneWare.ToolEngine.csproj"/>
         <ProjectReference Include="..\OneWare.UniversalFpgaProjectSystem\OneWare.UniversalFpgaProjectSystem.csproj"/>
     </ItemGroup>
+
+    <ItemGroup>
+        <!-- Toolchain skill for the FPGA agent, discovered at runtime from the output directory.
+             The relative Skills/<skill-name>/SKILL.md layout is what the host scans for. -->
+        <Content Include="Skills/**/*.md" CopyToOutputDirectory="PreserveNewest"/>
+    </ItemGroup>
 </Project>

--- a/src/OneWare.OssCadSuiteIntegration/OssCadSuiteIntegrationModule.cs
+++ b/src/OneWare.OssCadSuiteIntegration/OssCadSuiteIntegrationModule.cs
@@ -21,6 +21,7 @@ using OneWare.OssCadSuiteIntegration.Views;
 using OneWare.OssCadSuiteIntegration.Yosys;
 using OneWare.UniversalFpgaProjectSystem.Models;
 using OneWare.UniversalFpgaProjectSystem.Services;
+using OneWare.UniversalFpgaProjectSystem.Services.Ai;
 using OneWare.UniversalFpgaProjectSystem.ViewModels;
 
 // ReSharper disable StringLiteralTypo
@@ -348,6 +349,34 @@ public class OssCadSuiteIntegrationModule : OneWareModuleBase
         });
         
         serviceProvider.Resolve<IFileIconService>().RegisterFileIcon("Material.Pulse", GtkWaveService.GtkWaveformEndings);
+
+        RegisterToolchainSkill(serviceProvider);
+    }
+
+    /// <summary>
+    /// Contributes the Yosys toolchain skill to the IDE chat, so the FPGA agent knows how the
+    /// synthesis, place &amp; route and bitstream stages are configured and how to read a failed run.
+    /// </summary>
+    /// <remarks>
+    /// The chat is an optional module — the browser studio ships without it — so the registration is
+    /// skipped when no function provider is registered. Resolving it unconditionally would build a
+    /// second, unused provider through the container fallback.
+    /// </remarks>
+    private static void RegisterToolchainSkill(IServiceProvider serviceProvider)
+    {
+        if (!serviceProvider.IsRegistered<IAiFunctionProvider>()) return;
+
+        // The skill ships next to the assembly, one sub-directory with a SKILL.md.
+        var skillDirectory = FpgaSkillDirectoryLocator.TryResolve(typeof(OssCadSuiteIntegrationModule).Assembly);
+
+        if (skillDirectory is null)
+        {
+            serviceProvider.Resolve<ILogger>().Warning(
+                "The Yosys toolchain skill was not found next to the assembly. The FPGA agent runs without it.");
+            return;
+        }
+
+        serviceProvider.Resolve<IAiFunctionProvider>().RegisterSkillDirectory(skillDirectory);
     }
 
     private static bool IsOssPathValid(string path)

--- a/src/OneWare.OssCadSuiteIntegration/OssCadSuiteIntegrationModule.cs
+++ b/src/OneWare.OssCadSuiteIntegration/OssCadSuiteIntegrationModule.cs
@@ -114,7 +114,7 @@ public class OssCadSuiteIntegrationModule : OneWareModuleBase
                         },
                         new MenuItem()
                         {
-                            Header = "Run Fit",
+                            Header = "Run Place&Route",
                             Command = new AsyncRelayCommand(async () =>
                             {
                                 await projectExplorerService.SaveOpenFilesForProjectAsync(root);
@@ -123,7 +123,7 @@ public class OssCadSuiteIntegrationModule : OneWareModuleBase
                         },
                         new MenuItem()
                         {
-                            Header = "Run Assemble",
+                            Header = "Generate Bitstream",
                             Command = new AsyncRelayCommand(async () =>
                             {
                                 await projectExplorerService.SaveOpenFilesForProjectAsync(root);
@@ -133,7 +133,7 @@ public class OssCadSuiteIntegrationModule : OneWareModuleBase
                         new Separator(),
                         new MenuItem()
                         {
-                            Header = "Yosys Settings",
+                            Header = "Toolchain Settings",
                             Icon = new Image()
                             {
                                 Source = Application.Current!.FindResource(

--- a/src/OneWare.OssCadSuiteIntegration/OssCadSuiteIntegrationModule.cs
+++ b/src/OneWare.OssCadSuiteIntegration/OssCadSuiteIntegrationModule.cs
@@ -153,7 +153,7 @@ public class OssCadSuiteIntegrationModule : OneWareModuleBase
                                     if (selectedFpgaPackage == null)
                                     {
                                         serviceProvider.Resolve<ILogger>()
-                                            .Warning("No FPGA Selected. Open Pin Planner first!");
+                                            .Warning("No FPGA Selected. Open Constraints first!");
                                         return;
                                     }
 

--- a/src/OneWare.OssCadSuiteIntegration/Skills/fpga-toolchain-yosys/SKILL.md
+++ b/src/OneWare.OssCadSuiteIntegration/Skills/fpga-toolchain-yosys/SKILL.md
@@ -71,7 +71,7 @@ stops the build.
 | `ERROR: Module ... not found` from yosys | A source file is missing from the project or is in `compileExcluded`. |
 | `ERROR: Can't open input file` from yosys | The top entity name does not match any module. Check `fpga_list_top_entities`. |
 | `Cannot run place & route: build/synth.json is missing` | Synthesis did not produce a netlist — fix the synthesis error above it. |
-| nextpnr reports unconstrained or unknown pins | The constraint file does not match the design. Assign the pins in the pin planner. |
+| nextpnr reports unconstrained or unknown pins | The constraint file does not match the design. Assign the pins in the constraint editor. |
 | `... exited with code N` with no other error | The tool failed without a parseable message; the verbose option for that stage usually reveals why. |
 
 Do not re-run an identical build to "see if it works this time". The stages are deterministic and a

--- a/src/OneWare.OssCadSuiteIntegration/Skills/fpga-toolchain-yosys/SKILL.md
+++ b/src/OneWare.OssCadSuiteIntegration/Skills/fpga-toolchain-yosys/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: fpga-toolchain-yosys
+description: The Yosys/nextpnr toolchain in ONE WARE Studio — which device setting key controls which stage of the compile, what the build produces, and how to read a failed synthesis, place & route or bitstream run.
+---
+
+# The Yosys toolchain
+
+The `yosys` toolchain compiles an FPGA project in three stages that run in this order:
+
+1. **Synthesis** — `yosys` reads the HDL sources and writes `build/synth.json`.
+2. **Place & Route** — a `nextpnr-*` binary reads `build/synth.json` and the constraint file and
+   writes the placed and routed design into `build/`.
+3. **Bitstream** — a pack tool (`icepack`, `ecppack`, `gowin_pack`, `gmpack`) turns that into the
+   bitstream in `build/`.
+
+Everything is written below `build/` in the project folder. That folder is in the project's
+`exclude` list, so it does not show up as project content.
+
+**A stage only runs when the previous one succeeded.** Each stage deletes its own stale output
+before it starts and verifies that the expected artifact exists afterwards, so a build can never
+silently reuse a result from an earlier run. This matters when reading a failed compile: the first
+reported error is the real one, and there is no risk that a "successful" place & route was in fact
+routing yesterday's netlist.
+
+## Configuring the stages
+
+These are **device settings** of the selected board, stored in
+`device-settings/<board>.deviceconf`. Read them with `fpga_list_device_settings` and change them
+with `fpga_set_device_setting`. The same values are what the *Toolchain Settings* dialog under
+Compile shows, grouped into Synthesis, Place & Route and Bitstream.
+
+### Synthesis (Yosys)
+
+| Key | Meaning |
+| --- | --- |
+| `yosysToolchainYosysSynthTool` | The `synth_*` command for the target family, e.g. `synth_ice40`, `synth_ecp5`, `synth_gowin`. Must match the board. |
+| `yosysToolchainYosysFlags` | Extra flags passed to `yosys`. |
+| `yosysToolchainCommand` | Overrides the generated yosys script command entirely. Leave empty unless the default pipeline does not fit. |
+| `yosysQuietFlag` | `true` suppresses the yosys output. The dialog exposes the inverse as *Yosys Verbose*. |
+
+### Place & Route (nextpnr)
+
+| Key | Meaning |
+| --- | --- |
+| `yosysToolchainNextPnrTool` | The `nextpnr-*` binary, e.g. `nextpnr-ice40`, `nextpnr-ecp5`, `nextpnr-himbaechel`. Must match the synth tool's family. |
+| `yosysToolchainNextPnrFlags` | Extra flags, typically the device and package selection. |
+| `yosysToolchainConstraintFileType` | `pcf` or `ccf` — the constraint format the board uses. |
+| `yosysToolchainOutputType` | `asc` or `txt` — the place & route output format the pack tool expects. |
+| `yosysToolchainNextPnrVerbose` | `true` adds `--verbose` and shows the full nextpnr output in the Output panel. Turn this on when diagnosing timing or placement problems. |
+
+### Bitstream (pack)
+
+| Key | Meaning |
+| --- | --- |
+| `yosysToolchainPackTool` | `icepack`, `ecppack`, `gowin_pack` or `gmpack`, matching the family. |
+| `yosysToolchainPackFlags` | Extra flags for the pack tool. |
+| `packToolOutputFormat` | `bin` or `bit`. |
+
+The three tool selections must agree on the FPGA family: `synth_ice40` + `nextpnr-ice40` +
+`icepack` is consistent, mixing families is not. The hardware package of a board ships correct
+defaults, so only change them when the user targets a device the package does not cover.
+
+## Reading a failed compile
+
+The compile output goes to the Output panel, prefixed with the project name. A tool that exits with
+a non-zero status, or that prints a line starting with `Error:` / `ERROR:`, fails the stage and
+stops the build.
+
+| Symptom | Cause |
+| --- | --- |
+| `ERROR: Module ... not found` from yosys | A source file is missing from the project or is in `compileExcluded`. |
+| `ERROR: Can't open input file` from yosys | The top entity name does not match any module. Check `fpga_list_top_entities`. |
+| `Cannot run place & route: build/synth.json is missing` | Synthesis did not produce a netlist — fix the synthesis error above it. |
+| nextpnr reports unconstrained or unknown pins | The constraint file does not match the design. Assign the pins in the pin planner. |
+| `... exited with code N` with no other error | The tool failed without a parseable message; the verbose option for that stage usually reveals why. |
+
+Do not re-run an identical build to "see if it works this time". The stages are deterministic and a
+stale artifact can no longer mask a failure.
+
+## Programming
+
+After a successful build the loader writes the bitstream to the hardware:
+
+- **Config FPGA** loads the bitstream into the FPGA's volatile configuration. It is gone after a
+  power cycle.
+- **Write FLASH Memory** writes it into the board's FLASH, so the FPGA loads it on every power-up.
+
+Both need a bitstream from a completed build; the loader refuses to start without one.

--- a/src/OneWare.OssCadSuiteIntegration/ViewModels/OpenFpgaLoaderSettingsViewModel.cs
+++ b/src/OneWare.OssCadSuiteIntegration/ViewModels/OpenFpgaLoaderSettingsViewModel.cs
@@ -35,16 +35,16 @@ public class OpenFpgaLoaderSettingsViewModel : FlexibleWindowViewModelBase
             HoverDescription = "OpenFPGALoader Board"
         };
 
-        _shortTermFlagsSetting = new TextBoxSetting("Short Term Arguments",
+        _shortTermFlagsSetting = new TextBoxSetting("Config FPGA Arguments",
             defaultProperties.GetValueOrDefault("openFpgaLoaderShortTermFlags") ?? "", null)
         {
-            HoverDescription = "OpenFPGALoader Flags for Short Term Programming"
+            HoverDescription = "OpenFPGALoader Flags for Config FPGA"
         };
 
-        _longTermFlagsSetting = new TextBoxSetting("Long Term Arguments",
+        _longTermFlagsSetting = new TextBoxSetting("Write FLASH Memory Arguments",
             defaultProperties.GetValueOrDefault("openFpgaLoaderLongTermFlags") ?? "", null)
         {
-            HoverDescription = "OpenFPGALoader Flags for Long Term Programming"
+            HoverDescription = "OpenFPGALoader Flags for Write FLASH Memory"
         };
         
         _inputBitstreamFormat = new ComboBoxSetting("Pack output format",

--- a/src/OneWare.OssCadSuiteIntegration/ViewModels/YosysCompileSettingsViewModel.cs
+++ b/src/OneWare.OssCadSuiteIntegration/ViewModels/YosysCompileSettingsViewModel.cs
@@ -1,4 +1,5 @@
-﻿using OneWare.Essentials.Controls;
+﻿using System.Collections.ObjectModel;
+using OneWare.Essentials.Controls;
 using OneWare.Essentials.Models;
 using OneWare.Essentials.ViewModels;
 using OneWare.Settings.ViewModels;
@@ -21,6 +22,7 @@ public class YosysCompileSettingsViewModel : FlexibleWindowViewModelBase
     private readonly ComboBoxSetting _nextPnrToolSetting;
     private readonly ComboBoxSetting _nextPnrToolConstrainFileSetting;
     private readonly ComboBoxSetting _nextPnrToolOutputTypeSetting;
+    private readonly CheckBoxSetting _nextPnrVerboseSetting;
     private readonly TextBoxSetting _packToolFlagSetting;
     private readonly ComboBoxSetting _packToolSetting;
     private readonly IFpga _selectedFpga;
@@ -35,7 +37,7 @@ public class YosysCompileSettingsViewModel : FlexibleWindowViewModelBase
         _fpgaProjectRoot = fpgaProjectRoot;
         _selectedFpga = selectedFpga;
 
-        Title = "Yosys Compile Settings";
+        Title = "Toolchain Settings";
         Id = "YosysCompileSettings";
 
         var defaultProperties = _selectedFpga.Properties;
@@ -123,6 +125,12 @@ public class YosysCompileSettingsViewModel : FlexibleWindowViewModelBase
             HoverDescription = "Set NextPnr tool"
         };
         
+        _nextPnrVerboseSetting = new CheckBoxSetting("nextpnr Verbose",
+            bool.Parse(defaultProperties.GetValueOrDefault("yosysToolchainNextPnrVerbose") ?? "false"))
+        {
+            HoverDescription = "Show detailed nextpnr output in the Output panel"
+        };
+
         _packToolSetting = new ComboBoxSetting("Pack Tool",
             defaultProperties.GetValueOrDefault("yosysToolchainPackTool") ?? "", [
                 "ecppack",
@@ -149,19 +157,24 @@ public class YosysCompileSettingsViewModel : FlexibleWindowViewModelBase
             HoverDescription = "Set Pack tool output format"
         };
         
-        SettingsCollection.SettingModels.Add(_yosysSynthToolSetting);
-        SettingsCollection.SettingModels.Add(_yosysFlagSetting);
-        SettingsCollection.SettingModels.Add(_yosysCommandSetting);
-        SettingsCollection.SettingModels.Add(_yosysQuietFlagSetting);
+        SynthesisSettings.SettingModels.Add(_yosysSynthToolSetting);
+        SynthesisSettings.SettingModels.Add(_yosysFlagSetting);
+        SynthesisSettings.SettingModels.Add(_yosysCommandSetting);
+        SynthesisSettings.SettingModels.Add(_yosysQuietFlagSetting);
 
-        SettingsCollection.SettingModels.Add(_nextPnrToolSetting);
-        SettingsCollection.SettingModels.Add(_nextPnrFlagSetting);
-        SettingsCollection.SettingModels.Add(_nextPnrToolConstrainFileSetting);
-        SettingsCollection.SettingModels.Add(_nextPnrToolOutputTypeSetting);
+        PlaceAndRouteSettings.SettingModels.Add(_nextPnrToolSetting);
+        PlaceAndRouteSettings.SettingModels.Add(_nextPnrFlagSetting);
+        PlaceAndRouteSettings.SettingModels.Add(_nextPnrToolConstrainFileSetting);
+        PlaceAndRouteSettings.SettingModels.Add(_nextPnrToolOutputTypeSetting);
+        PlaceAndRouteSettings.SettingModels.Add(_nextPnrVerboseSetting);
 
-        SettingsCollection.SettingModels.Add(_packToolSetting);
-        SettingsCollection.SettingModels.Add(_packToolFlagSetting);
-        SettingsCollection.SettingModels.Add(_packOutputTypeSetting);
+        BitstreamSettings.SettingModels.Add(_packToolSetting);
+        BitstreamSettings.SettingModels.Add(_packToolFlagSetting);
+        BitstreamSettings.SettingModels.Add(_packOutputTypeSetting);
+
+        SettingsCollections.Add(SynthesisSettings);
+        SettingsCollections.Add(PlaceAndRouteSettings);
+        SettingsCollections.Add(BitstreamSettings);
 
         if (_settings.TryGetValue("yosysToolchainYosysSynthTool", out var yTool))
             _yosysSynthToolSetting.Value = yTool;
@@ -181,6 +194,9 @@ public class YosysCompileSettingsViewModel : FlexibleWindowViewModelBase
             _nextPnrToolConstrainFileSetting.Value = nConstrain;
         if (_settings.TryGetValue("yosysToolchainOutputType", out var nOutput))
             _nextPnrToolOutputTypeSetting.Value = nOutput;
+        if (_settings.TryGetValue("yosysToolchainNextPnrVerbose", out var nVerbose)
+            && bool.TryParse(nVerbose, out var verbose))
+            _nextPnrVerboseSetting.Value = verbose;
 
         if (_settings.TryGetValue("yosysToolchainPackTool", out var pTool))
             _packToolSetting.Value = pTool;
@@ -190,10 +206,13 @@ public class YosysCompileSettingsViewModel : FlexibleWindowViewModelBase
             _packOutputTypeSetting.Value = pOutput;
     }
 
-    public SettingsCollectionViewModel SettingsCollection { get; } = new("Yosys Settings")
-    {
-        ShowTitle = false
-    };
+    public SettingsCollectionViewModel SynthesisSettings { get; } = new("Synthesis (Yosys)");
+
+    public SettingsCollectionViewModel PlaceAndRouteSettings { get; } = new("Place & Route (nextpnr)");
+
+    public SettingsCollectionViewModel BitstreamSettings { get; } = new("Bitstream (Pack)");
+
+    public ObservableCollection<SettingsCollectionViewModel> SettingsCollections { get; } = [];
 
     public void Save(FlexibleWindow flexibleWindow)
     {
@@ -209,6 +228,7 @@ public class YosysCompileSettingsViewModel : FlexibleWindowViewModelBase
         _settings["yosysToolchainOutputType"] = _nextPnrToolOutputTypeSetting.Value.ToString()!;
         _settings["packToolOutputFormat"] = _packOutputTypeSetting.Value.ToString()!;
         _settings["yosysQuietFlag"] = (!(bool)_yosysQuietFlagSetting.Value).ToString();
+        _settings["yosysToolchainNextPnrVerbose"] = ((bool)_nextPnrVerboseSetting.Value).ToString();
 
         FpgaSettingsParser.SaveSettings(_fpgaProjectRoot, _selectedFpga.Name, _settings);
 
@@ -217,6 +237,8 @@ public class YosysCompileSettingsViewModel : FlexibleWindowViewModelBase
 
     public void Reset()
     {
-        foreach (var setting in SettingsCollection.SettingModels) setting.Value = setting.DefaultValue;
+        foreach (var collection in SettingsCollections)
+        foreach (var setting in collection.SettingModels)
+            setting.Value = setting.DefaultValue;
     }
 }

--- a/src/OneWare.OssCadSuiteIntegration/Views/YosysCompileSettingsView.axaml
+++ b/src/OneWare.OssCadSuiteIntegration/Views/YosysCompileSettingsView.axaml
@@ -5,12 +5,12 @@
                          xmlns:controls="clr-namespace:OneWare.Essentials.Controls;assembly=OneWare.Essentials"
                          xmlns:viewModels="clr-namespace:OneWare.OssCadSuiteIntegration.ViewModels"
                          xmlns:behaviors="clr-namespace:OneWare.Essentials.Behaviors;assembly=OneWare.Essentials"
-                         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450" PrefHeight="370" PrefWidth="400"
+                         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450" PrefHeight="520" PrefWidth="420"
                          CustomIcon="{DynamicResource Material.SettingsOutline}"
                          Icon="avares://OneWare.Core/Assets/Images/Icons/Settings_White.png"
                          x:Class="OneWare.OssCadSuiteIntegration.Views.YosysCompileSettingsView"
                          Name="YosysCompileSettingsViewView"
-                         WindowStartupLocation="CenterOwner" Title="Yosys Compile Settings"
+                         WindowStartupLocation="CenterOwner" Title="Toolchain Settings"
                          x:DataType="viewModels:YosysCompileSettingsViewModel">
     <Interaction.Behaviors>
         <behaviors:CommandOnKeyPressedBehavior TriggerKey="Enter" Command="{Binding Save}"
@@ -28,7 +28,13 @@
             </Button>
         </StackPanel>
         <ScrollViewer DockPanel.Dock="Top">
-            <ContentControl Padding="4" Content="{Binding SettingsCollection}" />
+            <ItemsControl Padding="4" ItemsSource="{Binding SettingsCollections}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Vertical" Spacing="4" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+            </ItemsControl>
         </ScrollViewer>
     </DockPanel>
 </controls:FlexibleWindow>

--- a/src/OneWare.OssCadSuiteIntegration/Yosys/YosysService.cs
+++ b/src/OneWare.OssCadSuiteIntegration/Yosys/YosysService.cs
@@ -37,9 +37,22 @@ public class YosysService(
 
         outputService.WriteLine("Compiling...\n==================");
 
+        var failedStage = string.Empty;
+
         var success = await SynthAsync(project, fpgaModel, mandatoryFiles);
-        success = success && await FitAsync(project, fpgaModel);
-        success = success && await AssembleAsync(project, fpgaModel);
+        if (!success) failedStage = "Synthesis";
+
+        if (success)
+        {
+            success = await FitAsync(project, fpgaModel);
+            if (!success) failedStage = "Place&Route";
+        }
+
+        if (success)
+        {
+            success = await AssembleAsync(project, fpgaModel);
+            if (!success) failedStage = "Generate Bitstream";
+        }
 
         var compileTime = DateTime.Now - start;
 
@@ -48,7 +61,7 @@ public class YosysService(
                 $"==================\n\nCompilation finished after {(int)compileTime.TotalMinutes:D2}:{compileTime.Seconds:D2}\n");
         else
             outputService.WriteLine(
-                $"==================\n\nCompilation failed after {(int)compileTime.TotalMinutes:D2}:{compileTime.Seconds:D2}\n",
+                $"==================\n\nCompilation failed in stage '{failedStage}' after {(int)compileTime.TotalMinutes:D2}:{compileTime.Seconds:D2}\n",
                 Brushes.Red);
 
         return success;
@@ -65,6 +78,8 @@ public class YosysService(
         {
             var properties = FpgaSettingsParser.LoadSettings(project, fpgaModel.Fpga.Name);
             var top = project.TopEntity ?? throw new Exception("TopEntity not set!");
+
+            Directory.CreateDirectory(Path.Combine(project.FullPath, "build"));
 
             var includedFiles = project.GetFiles("*.v").Concat(project.GetFiles("*.sv"))
                 .Where(x => !project.IsCompileExcluded(x))
@@ -83,14 +98,18 @@ public class YosysService(
             
             var yosysSynthTool = properties.GetValueOrDefault("yosysToolchainYosysSynthTool") ??
                                  throw new Exception("Yosys Tool not set. This hardware might not be configured to be used with Yosys Toolchain");
-            
+
+            const string synthOutput = "build/synth.json";
+            // Remove a previous result so a failing run can never be followed by a stale netlist
+            DeleteArtifact(project, synthOutput);
+
             var builder = toolExecutionDispatcherService.CreateToolCommandBuilder("yosys")
                 .WithWorkingDirectory(project.FullPath)
                 .WithStatus("Running yosys...")
                 .WithTimer(true)
                 .WithOutputHandler(x =>
                 {
-                    if (x.StartsWith("Error:"))
+                    if (IsErrorLine(x))
                     {
                         logger.Error(x);
                         return false;
@@ -101,7 +120,7 @@ public class YosysService(
                 })
                 .WithErrorHandler(x =>
                 {
-                    if (x.StartsWith("Error:", StringComparison.OrdinalIgnoreCase))
+                    if (IsErrorLine(x))
                     {
                         logger.Error(x);
                         return false;
@@ -145,6 +164,13 @@ public class YosysService(
             var command = builder.Build();
 
             var (success, _) = await toolExecutionDispatcherService.ExecuteAsync(command);
+
+            if (success && !ArtifactExists(project, synthOutput))
+            {
+                logger.Error($"Yosys did not produce '{synthOutput}'. Synthesis failed.");
+                return false;
+            }
+
             return success;
         }
         catch (Exception e)
@@ -168,12 +194,41 @@ public class YosysService(
             var nextPnrTool = properties.GetValueOrDefault("yosysToolchainNextPnrTool")
                               ?? throw new Exception("NextPnr Tool not set!");
 
+            Directory.CreateDirectory(Path.Combine(project.FullPath, "build"));
+
+            const string synthInput = "build/synth.json";
+            if (!ArtifactExists(project, synthInput))
+            {
+                logger.Error(
+                    $"'{synthInput}' not found. Run Synthesis successfully before running Place&Route.");
+                return false;
+            }
+
+            bool.TryParse(properties.GetValueOrDefault("yosysToolchainNextPnrVerbose") ?? "false", out var verbose);
+
             var builder = toolExecutionDispatcherService.CreateToolCommandBuilder(nextPnrTool)
                 .WithWorkingDirectory(project.FullPath)
                 .WithStatus($"Running {nextPnrTool}...")
                 .WithTimer(true)
+                .WithOutputHandler(s =>
+                {
+                    if (IsErrorLine(s))
+                    {
+                        logger.Error(s);
+                        return false;
+                    }
+
+                    Dispatcher.UIThread.Post(() => { outputService.WriteLine(s); });
+                    return true;
+                })
                 .WithErrorHandler(s =>
                 {
+                    if (IsErrorLine(s))
+                    {
+                        logger.Error(s);
+                        return false;
+                    }
+
                     Dispatcher.UIThread.Post(() => { outputService.WriteLine(s); });
                     return true;
                 });
@@ -212,21 +267,29 @@ public class YosysService(
             }
 
             var cOutputType = properties.GetValueOrDefault("yosysToolchainOutputType", "asc");
+            string pnrOutput;
             switch (cOutputType)
             {
                 case "asc":
-                    builder.Add("--asc").AddPath("./build/nextpnr.asc");
+                    pnrOutput = "./build/nextpnr.asc";
+                    builder.Add("--asc").AddPath(pnrOutput);
                     break;
                 case "txt":
+                    pnrOutput = "./build/impl.txt";
                     builder.Add("-o");
-                    builder.AddScript("out={path}", ("{path}", "./build/impl.txt"));
+                    builder.AddScript("out={path}", ("{path}", pnrOutput));
                     break;
                 default:
                     outputService.WriteLine($"Could not find output type: {cOutputType}");
                     return false;
             }
 
+            // Remove a previous result so a failing run can never be followed by a stale bitstream
+            if (!withGui) DeleteArtifact(project, pnrOutput);
+
             if (withGui) builder.Add("--gui");
+
+            if (verbose) builder.Add("--verbose");
 
             var extraFlags = properties.GetValueOrDefault("yosysToolchainNextPnrFlags")?
                 .Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries) ?? [];
@@ -235,7 +298,16 @@ public class YosysService(
 
             var command = builder.Build();
             var status = await toolExecutionDispatcherService.ExecuteAsync(command);
-            return status.success;
+
+            if (!status.success) return false;
+
+            if (!withGui && !ArtifactExists(project, pnrOutput))
+            {
+                logger.Error($"{nextPnrTool} did not produce '{pnrOutput}'. Place&Route failed.");
+                return false;
+            }
+
+            return true;
         }
         catch (Exception e)
         {
@@ -252,12 +324,20 @@ public class YosysService(
             var packTool = properties.GetValueOrDefault("yosysToolchainPackTool")
                            ?? throw new Exception("Pack Tool not set!");
 
+            Directory.CreateDirectory(Path.Combine(project.FullPath, "build"));
+
             var builder = toolExecutionDispatcherService.CreateToolCommandBuilder(packTool)
                 .WithWorkingDirectory(project.FullPath)
                 .WithStatus($"Running {packTool}...")
                 .WithTimer(true)
                 .WithErrorHandler(s =>
                 {
+                    if (IsErrorLine(s))
+                    {
+                        logger.Error(s);
+                        return false;
+                    }
+
                     Dispatcher.UIThread.Post(() => { outputService.WriteLine(s); });
                     return true;
                 });
@@ -269,6 +349,14 @@ public class YosysService(
                 "txt" => "./build/impl.txt",
                 _ => throw new ArgumentException($"Unsupported input type: {cOutputType}")
             };
+
+            if (!ArtifactExists(project, inputPath))
+            {
+                logger.Error(
+                    $"'{inputPath}' not found. Run Place&Route successfully before generating the bitstream.");
+                return false;
+            }
+
             builder.AddPath(inputPath);
 
             var pOutputFormat = properties.GetValueOrDefault("packToolOutputFormat", "bin");
@@ -278,6 +366,10 @@ public class YosysService(
                 "bit" => "./build/pack.bit",
                 _ => throw new ArgumentException($"Unsupported output format: {pOutputFormat}")
             };
+
+            // Remove a previous result so a failing run can never be followed by a stale bitstream
+            DeleteArtifact(project, outputPath);
+
             builder.AddPath(outputPath);
 
             var flags = properties.GetValueOrDefault("yosysToolchainPackFlags")?.Split(' ',
@@ -291,7 +383,16 @@ public class YosysService(
             var command = builder.Build();
 
             var status = await toolExecutionDispatcherService.ExecuteAsync(command);
-            return status.success;
+
+            if (!status.success) return false;
+
+            if (!ArtifactExists(project, outputPath))
+            {
+                logger.Error($"{packTool} did not produce '{outputPath}'. Bitstream generation failed.");
+                return false;
+            }
+
+            return true;
         }
         catch (Exception e)
         {
@@ -330,6 +431,29 @@ public class YosysService(
 
         await toolExecutionDispatcherService.ExecuteAsync(command);
         return ReadJson(Path.Combine(buildpath, "yosys_nodes.json"));
+    }
+
+    private static bool IsErrorLine(string line)
+    {
+        return line.TrimStart().StartsWith("Error:", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void DeleteArtifact(UniversalFpgaProjectRoot project, string relativePath)
+    {
+        try
+        {
+            var fullPath = Path.Combine(project.FullPath, relativePath);
+            if (File.Exists(fullPath)) File.Delete(fullPath);
+        }
+        catch (Exception)
+        {
+            // Deleting is best effort, the artifact existence check below reports real problems
+        }
+    }
+
+    private static bool ArtifactExists(UniversalFpgaProjectRoot project, string relativePath)
+    {
+        return File.Exists(Path.Combine(project.FullPath, relativePath));
     }
 
     private List<FpgaNode> ReadJson(string filePath)

--- a/src/OneWare.UniversalFpgaProjectSystem/Fpga/PinPropertyDefinition.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Fpga/PinPropertyDefinition.cs
@@ -14,11 +14,11 @@ public enum PinPropertyType
 
 /// <summary>
 /// Declares a per-pin property that a hardware support module (e.g. Quartus Agilex toolchain)
-/// wants to expose in the pin planner UI and persist via
+/// wants to expose in the constraint editor UI and persist via
 /// <see cref="IFpgaToolchain.SaveConnections"/> / <see cref="IFpgaToolchain.LoadConnections"/>.
 /// </summary>
 /// <param name="Key">Unique identifier used as the dictionary key in <c>HardwarePinModel.PinPropertyValues</c>.</param>
-/// <param name="DisplayName">Column header shown in the pin planner table.</param>
+/// <param name="DisplayName">Column header shown in the constraint editor table.</param>
 /// <param name="Type">Whether the cell renders as a text box or a combo box.</param>
 /// <param name="AllowedValues">Allowed options when <paramref name="Type"/> is <see cref="PinPropertyType.ComboBox"/>.</param>
 public record PinPropertyDefinition(

--- a/src/OneWare.UniversalFpgaProjectSystem/Models/FpgaModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Models/FpgaModel.cs
@@ -120,7 +120,7 @@ public sealed class FpgaModel : ObservableObject, IHardwareModel
 
     public event EventHandler? NodeDisconnected;
 
-    /// <summary>Raised when any pin's per-pin property value changes (triggers IsDirty in the pin planner).</summary>
+    /// <summary>Raised when any pin's per-pin property value changes (triggers IsDirty in the constraint editor).</summary>
     public event EventHandler? PinPropertyChanged;
 
     private void SearchPins(string? search)

--- a/src/OneWare.UniversalFpgaProjectSystem/OneWare.UniversalFpgaProjectSystem.csproj
+++ b/src/OneWare.UniversalFpgaProjectSystem/OneWare.UniversalFpgaProjectSystem.csproj
@@ -12,4 +12,10 @@
         <ProjectReference Include="..\OneWare.Essentials\OneWare.Essentials.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <!-- Skills for the FPGA agent, discovered at runtime from the output directory.
+             The relative Skills/<skill-name>/SKILL.md layout is what the host scans for. -->
+        <Content Include="Skills/**/*.md" CopyToOutputDirectory="PreserveNewest"/>
+    </ItemGroup>
+
 </Project>

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaAgentContext.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaAgentContext.cs
@@ -1,0 +1,127 @@
+using OneWare.Essentials.Models;
+using OneWare.Essentials.Services;
+using OneWare.UniversalFpgaProjectSystem.Models;
+
+namespace OneWare.UniversalFpgaProjectSystem.Services.Ai;
+
+/// <summary>
+/// Raised when an FPGA chat function cannot do its work, for example because no FPGA project is
+/// active or an argument does not match anything in the project.
+/// </summary>
+public sealed class FpgaAgentException : Exception
+{
+    public FpgaAgentException(string message) : base(message)
+    {
+    }
+
+    public FpgaAgentException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// Gives the FPGA chat functions access to the project the user currently works on.
+/// </summary>
+/// <remarks>
+/// The chat has no notion of the project explorer selection, so every function resolves the active
+/// project through this single entry point in order to produce one consistent error message when
+/// there is none.
+/// </remarks>
+public sealed class FpgaAgentContext(IProjectExplorerService projectExplorerService)
+{
+    private const string NoProjectMessage =
+        "No FPGA project is active. Call fpga_list_projects and fpga_set_active_project, or create " +
+        "one with fpga_create_project.";
+
+    public IProjectExplorerService ProjectExplorerService { get; } = projectExplorerService;
+
+    /// <summary>
+    /// Returns the active FPGA project.
+    /// </summary>
+    /// <exception cref="FpgaAgentException">No FPGA project is active.</exception>
+    public UniversalFpgaProjectRoot RequireProject()
+    {
+        if (ProjectExplorerService.ActiveProject is not UniversalFpgaProjectRoot project)
+            throw new FpgaAgentException(NoProjectMessage);
+
+        return project;
+    }
+
+    /// <summary>
+    /// Returns every loaded FPGA project.
+    /// </summary>
+    public IReadOnlyList<UniversalFpgaProjectRoot> GetProjects()
+    {
+        return ProjectExplorerService.Projects.OfType<UniversalFpgaProjectRoot>().ToList();
+    }
+
+    /// <summary>
+    /// Resolves a loaded FPGA project by name or by (partial) project file path.
+    /// </summary>
+    /// <exception cref="FpgaAgentException">Nothing matched, or the name was ambiguous.</exception>
+    public UniversalFpgaProjectRoot ResolveProject(string nameOrPath)
+    {
+        if (string.IsNullOrWhiteSpace(nameOrPath))
+            throw new FpgaAgentException("Pass the name or the .fpgaproj path of the project.");
+
+        var projects = GetProjects();
+
+        if (projects.Count == 0)
+            throw new FpgaAgentException("No FPGA project is loaded. Create one with fpga_create_project.");
+
+        var needle = nameOrPath.Trim();
+
+        var matches = projects
+            .Where(x => string.Equals(x.Name, needle, StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(x.ProjectFilePath, needle, StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(x.RootFolderPath, needle, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (matches.Count == 0)
+            matches = projects
+                .Where(x => x.ProjectFilePath.Contains(needle, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+        return matches.Count switch
+        {
+            1 => matches[0],
+            0 => throw new FpgaAgentException(
+                $"No loaded FPGA project matches '{nameOrPath}'. Loaded projects: " +
+                $"{string.Join(", ", projects.Select(x => x.Name))}."),
+            _ => throw new FpgaAgentException(
+                $"'{nameOrPath}' matches several projects: " +
+                $"{string.Join(", ", matches.Select(x => x.ProjectFilePath))}. Pass the full path.")
+        };
+    }
+
+    /// <summary>
+    /// Resolves a project file from a relative or absolute path.
+    /// </summary>
+    /// <exception cref="FpgaAgentException">The file is not part of the project.</exception>
+    public IProjectFile RequireFile(UniversalFpgaProjectRoot project, string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new FpgaAgentException("Pass the path of a file that belongs to the project.");
+
+        var relative = ToRelativePath(project, path);
+
+        if (project.GetFile(relative) is { } file) return file;
+
+        throw new FpgaAgentException(
+            $"'{path}' is not a file of project '{project.Name}'. Call fpga_list_files to see the " +
+            "exact relative paths.");
+    }
+
+    /// <summary>
+    /// Converts an absolute path into a project relative one, and normalizes the separators.
+    /// </summary>
+    public static string ToRelativePath(UniversalFpgaProjectRoot project, string path)
+    {
+        var trimmed = path.Trim();
+
+        if (Path.IsPathRooted(trimmed))
+            trimmed = Path.GetRelativePath(project.RootFolderPath, trimmed);
+
+        return trimmed.Replace('\\', '/');
+    }
+}

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaAiFunctionRegistrar.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaAiFunctionRegistrar.cs
@@ -1,0 +1,68 @@
+using OneWare.Essentials.Models;
+using OneWare.Essentials.Services;
+
+namespace OneWare.UniversalFpgaProjectSystem.Services.Ai;
+
+/// <summary>
+/// Registers all FPGA chat functions with the IDE chat.
+/// </summary>
+/// <remarks>
+/// This is the only place that knows every function group, which keeps the individual groups free
+/// of registration concerns and gives the agent a single, authoritative tool list.
+/// </remarks>
+public static class FpgaAiFunctionRegistrar
+{
+    /// <summary>
+    /// Registers every FPGA chat function.
+    /// </summary>
+    /// <param name="aiFunctionProvider">The chat function provider of the IDE.</param>
+    /// <param name="fpgaService">Provides the registered toolchains, loaders, simulators and boards.</param>
+    /// <param name="projectExplorerService">Resolves and saves the active project.</param>
+    /// <param name="projectManager">Loads and saves .fpgaproj files.</param>
+    /// <param name="projectSettingsService">Provides the settings plugins registered for a project.</param>
+    /// <param name="paths">Provides the default projects directory.</param>
+    /// <returns>The names of the registered functions, in registration order.</returns>
+    public static IReadOnlyList<string> Register(
+        IAiFunctionProvider aiFunctionProvider,
+        FpgaService fpgaService,
+        IProjectExplorerService projectExplorerService,
+        UniversalFpgaProjectManager projectManager,
+        IProjectSettingsService projectSettingsService,
+        IPaths paths)
+    {
+        ArgumentNullException.ThrowIfNull(aiFunctionProvider);
+
+        var functions = CreateFunctions(fpgaService, projectExplorerService, projectManager,
+            projectSettingsService, paths);
+
+        foreach (var function in functions)
+            aiFunctionProvider.RegisterFunction(function);
+
+        return functions.Select(x => x.Name).ToList();
+    }
+
+    internal static IReadOnlyList<IOneWareAiFunction> CreateFunctions(
+        FpgaService fpgaService,
+        IProjectExplorerService projectExplorerService,
+        UniversalFpgaProjectManager projectManager,
+        IProjectSettingsService projectSettingsService,
+        IPaths paths)
+    {
+        ArgumentNullException.ThrowIfNull(fpgaService);
+        ArgumentNullException.ThrowIfNull(projectExplorerService);
+        ArgumentNullException.ThrowIfNull(projectManager);
+        ArgumentNullException.ThrowIfNull(projectSettingsService);
+        ArgumentNullException.ThrowIfNull(paths);
+
+        var context = new FpgaAgentContext(projectExplorerService);
+
+        var functions = new List<IOneWareAiFunction>();
+        functions.AddRange(new FpgaProjectFunctions(context, fpgaService, projectManager, paths).CreateFunctions());
+        functions.AddRange(new FpgaToolchainFunctions(context, fpgaService, projectManager).CreateFunctions());
+        functions.AddRange(new FpgaSettingsFunctions(context, fpgaService, projectManager, projectSettingsService)
+            .CreateFunctions());
+        functions.AddRange(new FpgaFileFunctions(context, projectManager).CreateFunctions());
+        functions.AddRange(new FpgaSimulationFunctions(context, fpgaService).CreateFunctions());
+        return functions;
+    }
+}

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaFileFunctions.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaFileFunctions.cs
@@ -1,0 +1,148 @@
+using System.ComponentModel;
+using System.Text;
+using OneWare.Essentials.Models;
+using OneWare.UniversalFpgaProjectSystem.Models;
+
+namespace OneWare.UniversalFpgaProjectSystem.Services.Ai;
+
+/// <summary>
+/// Chat functions for the per-file flags of an FPGA project: which files are excluded from
+/// compilation and which ones are test benches.
+/// </summary>
+public sealed class FpgaFileFunctions(
+    FpgaAgentContext context,
+    UniversalFpgaProjectManager projectManager)
+{
+    /// <summary>
+    /// Creates the functions this group contributes to the chat.
+    /// </summary>
+    public IEnumerable<IOneWareAiFunction> CreateFunctions()
+    {
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_list_files",
+            FriendlyName = "List FPGA project files",
+            DetailExtractor = FpgaFunctionDetail.FirstOf("project files", "searchPattern"),
+            Description = "Lists the files of the active FPGA project with their flags: [excluded] when the " +
+                          "file is excluded from compilation, [testbench] when it is registered as a test " +
+                          "bench and [top] when it declares the top entity. Use the relative paths it returns " +
+                          "for the other fpga_* file functions.",
+            Handler = (Func<string?, string>)ListFiles,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_set_compile_excluded",
+            FriendlyName = "Exclude file from compilation",
+            DetailExtractor = FpgaFunctionDetail.AllOf("compile exclusion", "path", "excluded"),
+            Description = "Excludes a project file from compilation, or includes it again. Excluded files are " +
+                          "not passed to synthesis; use this for alternative implementations or for sources " +
+                          "that only the simulator needs.",
+            Handler = (Func<string, string, Task<string>>)SetCompileExcludedAsync,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_set_testbench",
+            FriendlyName = "Mark file as test bench",
+            DetailExtractor = FpgaFunctionDetail.AllOf("test bench", "path", "isTestBench"),
+            Description = "Marks a project file as a test bench, or removes that mark. Test benches are " +
+                          "skipped when searching for the top entity and can be run with fpga_run_simulation.",
+            Handler = (Func<string, string, Task<string>>)SetTestBenchAsync,
+            RunOnUiThread = true
+        };
+    }
+
+    private string ListFiles(
+        [Description("Glob pattern to filter the files, for example '*.v'. Defaults to every file.")]
+        string? searchPattern = null)
+    {
+        return FpgaFunctionGuard.Run(() =>
+        {
+            var project = context.RequireProject();
+            var pattern = string.IsNullOrWhiteSpace(searchPattern) ? "*" : searchPattern.Trim();
+
+            var files = project.GetFiles(pattern)
+                .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (files.Count == 0)
+                return $"No file of '{project.Name}' matches '{pattern}'.";
+
+            var builder = new StringBuilder();
+            builder.AppendLine($"{files.Count} file(s) in '{project.Name}':");
+
+            foreach (var file in files)
+            {
+                var flags = new List<string>();
+
+                if (project.IsCompileExcluded(file)) flags.Add("excluded");
+                if (project.IsTestBench(file)) flags.Add("testbench");
+                if (project.TopEntityFilePath == file) flags.Add("top");
+
+                builder.AppendLine($"  - {file}{(flags.Count == 0 ? "" : $" [{string.Join(", ", flags)}]")}");
+            }
+
+            return builder.ToString().TrimEnd();
+        });
+    }
+
+    private Task<string> SetCompileExcludedAsync(
+        [Description("Path of the file, relative to the project root or absolute.")]
+        string path,
+        [Description("true to exclude the file from compilation, false to include it again.")]
+        string excluded)
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+            var file = context.RequireFile(project, path);
+            var exclude = FpgaFunctionText.ParseBool(excluded, nameof(excluded));
+
+            if (exclude)
+                project.AddCompileExcluded(file.RelativePath);
+            else
+                project.RemoveCompileExcluded(file.RelativePath);
+
+            await SaveAsync(project);
+
+            return exclude
+                ? $"'{file.RelativePath}' is now excluded from compilation."
+                : $"'{file.RelativePath}' is compiled again.";
+        });
+    }
+
+    private Task<string> SetTestBenchAsync(
+        [Description("Path of the file, relative to the project root or absolute.")]
+        string path,
+        [Description("true to mark the file as a test bench, false to remove the mark.")]
+        string isTestBench)
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+            var file = context.RequireFile(project, path);
+            var mark = FpgaFunctionText.ParseBool(isTestBench, nameof(isTestBench));
+
+            if (mark)
+                project.AddTestBench(file.RelativePath);
+            else
+                project.RemoveTestBench(file.RelativePath);
+
+            await SaveAsync(project);
+
+            return mark
+                ? $"'{file.RelativePath}' is now a test bench. Select its simulator with " +
+                  "fpga_set_testbench_simulator."
+                : $"'{file.RelativePath}' is no longer a test bench.";
+        });
+    }
+
+    private async Task SaveAsync(UniversalFpgaProjectRoot project)
+    {
+        if (!await projectManager.SaveProjectAsync(project))
+            throw new FpgaAgentException($"'{project.Name}' could not be saved.");
+    }
+}

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaFunctionGuard.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaFunctionGuard.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Logging;
+using OneWare.Essentials.Services;
+
+namespace OneWare.UniversalFpgaProjectSystem.Services.Ai;
+
+/// <summary>
+/// Turns exceptions raised inside an FPGA chat function into a message the model can act on.
+/// </summary>
+/// <remarks>
+/// A thrown exception aborts the tool call and gives the model nothing to work with. Returning the
+/// reason as text lets it correct the call — a wrong toolchain id, a project that is not active —
+/// without a round trip through the user.
+/// </remarks>
+public static class FpgaFunctionGuard
+{
+    /// <summary>
+    /// Runs <paramref name="action"/> and converts failures into a readable reply.
+    /// </summary>
+    public static string Run(Func<string> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        try
+        {
+            return action();
+        }
+        catch (FpgaAgentException e)
+        {
+            return $"Error: {e.Message}";
+        }
+        catch (OperationCanceledException)
+        {
+            return "Cancelled: the tool stopped before it completed.";
+        }
+        catch (Exception e)
+        {
+            ContainerLocator.Container.Resolve<ILogger>()?.Error(e.Message, e);
+            return $"Error: {e.Message}";
+        }
+    }
+
+    /// <summary>
+    /// Runs <paramref name="action"/> and converts failures into a readable reply.
+    /// </summary>
+    public static async Task<string> RunAsync(Func<Task<string>> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        try
+        {
+            return await action();
+        }
+        catch (FpgaAgentException e)
+        {
+            return $"Error: {e.Message}";
+        }
+        catch (OperationCanceledException)
+        {
+            return "Cancelled: the tool stopped before it completed.";
+        }
+        catch (Exception e)
+        {
+            ContainerLocator.Container.Resolve<ILogger>()?.Error(e.Message, e);
+            return $"Error: {e.Message}";
+        }
+    }
+}

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaFunctionText.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaFunctionText.cs
@@ -1,0 +1,186 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace OneWare.UniversalFpgaProjectSystem.Services.Ai;
+
+/// <summary>
+/// Formatting helpers shared by the FPGA chat functions, so every reply uses the same shape.
+/// </summary>
+public static class FpgaFunctionText
+{
+    /// <summary>Appends a <c>Name: value</c> line, using a placeholder for empty values.</summary>
+    public static void AppendField(StringBuilder builder, string name, object? value)
+    {
+        var text = value?.ToString();
+
+        builder.AppendLine($"{name}: {(string.IsNullOrWhiteSpace(text) ? "(unset)" : text)}");
+    }
+
+    /// <summary>Appends a bullet list, or a placeholder when the list is empty.</summary>
+    public static void AppendList(StringBuilder builder, string title, IEnumerable<string> items,
+        string emptyText = "(none)")
+    {
+        var list = items.ToList();
+
+        builder.AppendLine($"{title}:");
+
+        if (list.Count == 0)
+        {
+            builder.AppendLine($"  {emptyText}");
+            return;
+        }
+
+        foreach (var item in list) builder.AppendLine($"  - {item}");
+    }
+
+    /// <summary>Parses a boolean argument, accepting the spellings a model is likely to produce.</summary>
+    /// <exception cref="FpgaAgentException">The value is not a boolean.</exception>
+    public static bool ParseBool(string value, string argumentName)
+    {
+        var trimmed = value.Trim();
+
+        if (bool.TryParse(trimmed, out var parsed)) return parsed;
+
+        return trimmed.ToLowerInvariant() switch
+        {
+            "1" or "yes" or "y" or "on" or "enabled" => true,
+            "0" or "no" or "n" or "off" or "disabled" => false,
+            _ => throw new FpgaAgentException(
+                $"'{value}' is not a boolean value for '{argumentName}'. Use true or false.")
+        };
+    }
+
+    /// <summary>Throws when a required text argument is missing.</summary>
+    /// <exception cref="FpgaAgentException">The argument is empty.</exception>
+    public static string Require(string? value, string argumentName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new FpgaAgentException($"The argument '{argumentName}' is required.");
+
+        return value.Trim();
+    }
+}
+
+/// <summary>
+/// Builds the short detail string the chat shows next to a running FPGA tool call.
+/// </summary>
+/// <remarks>
+/// While a function runs the chat only shows its friendly name, which makes a transcript of several
+/// <c>fpga_set_device_setting</c> calls unreadable. Each function therefore contributes a detail
+/// naming what it acts on, derived from the actual invocation arguments.
+/// </remarks>
+public static class FpgaFunctionDetail
+{
+    /// <summary>Details longer than this are cut, so a long argument cannot break the layout.</summary>
+    private const int MaxLength = 80;
+
+    /// <summary>Builds a detail that does not depend on the arguments.</summary>
+    public static Func<AIFunctionArguments, string?> Constant(string detail)
+    {
+        return _ => detail;
+    }
+
+    /// <summary>Builds a detail from the first argument that has a value.</summary>
+    public static Func<AIFunctionArguments, string?> FirstOf(string fallback, params string[] argumentNames)
+    {
+        ArgumentNullException.ThrowIfNull(argumentNames);
+
+        return arguments =>
+        {
+            foreach (var name in argumentNames)
+                if (GetString(arguments, name) is { } value)
+                    return Shorten(value);
+
+            return fallback;
+        };
+    }
+
+    /// <summary>Builds a detail that joins every argument that has a value.</summary>
+    public static Func<AIFunctionArguments, string?> AllOf(string fallback, params string[] argumentNames)
+    {
+        ArgumentNullException.ThrowIfNull(argumentNames);
+
+        return arguments =>
+        {
+            var values = new List<string>(argumentNames.Length);
+
+            foreach (var name in argumentNames)
+                if (GetString(arguments, name) is { } value)
+                    values.Add(value.Trim());
+
+            return values.Count == 0 ? fallback : Shorten(string.Join(' ', values));
+        };
+    }
+
+    /// <summary>
+    /// Reads an invocation argument as text.
+    /// </summary>
+    /// <remarks>
+    /// Depending on how the model call was deserialized a value arrives either as a CLR type or as a
+    /// <see cref="JsonElement"/>, so both shapes are handled here.
+    /// </remarks>
+    private static string? GetString(AIFunctionArguments? arguments, string name)
+    {
+        if (arguments is null || !arguments.TryGetValue(name, out var raw) || raw is null)
+            return null;
+
+        var text = raw switch
+        {
+            string s => s,
+            JsonElement { ValueKind: JsonValueKind.Null or JsonValueKind.Undefined } => null,
+            JsonElement { ValueKind: JsonValueKind.String } json => json.GetString(),
+            JsonElement json => json.ToString(),
+            IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+            _ => raw.ToString()
+        };
+
+        return string.IsNullOrWhiteSpace(text) ? null : text;
+    }
+
+    /// <summary>Cuts a detail to the display length.</summary>
+    private static string Shorten(string detail)
+    {
+        var single = detail.ReplaceLineEndings(" ").Trim();
+
+        return single.Length <= MaxLength ? single : string.Concat(single.AsSpan(0, MaxLength - 1), "…");
+    }
+}
+
+/// <summary>
+/// Resolves the directory the FPGA agent skills are deployed to.
+/// </summary>
+/// <remarks>
+/// The skills are copied next to the assembly by the build, so resolving them depends on the
+/// assembly having a physical location. That is not guaranteed for every deployment model, so the
+/// lookup fails softly instead of tearing down module initialisation.
+/// </remarks>
+public static class FpgaSkillDirectoryLocator
+{
+    /// <summary>Name of the folder the skills are deployed to, relative to the assembly.</summary>
+    public const string SkillFolderName = "Skills";
+
+    /// <summary>Resolves the skill directory that belongs to <paramref name="assembly"/>.</summary>
+    public static string? TryResolve(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        return TryResolve(assembly.Location);
+    }
+
+    /// <summary>Resolves the skill directory next to <paramref name="assemblyLocation"/>.</summary>
+    public static string? TryResolve(string? assemblyLocation)
+    {
+        if (string.IsNullOrEmpty(assemblyLocation)) return null;
+
+        var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
+
+        if (string.IsNullOrEmpty(assemblyDirectory)) return null;
+
+        var skillDirectory = Path.Combine(assemblyDirectory, SkillFolderName);
+
+        return Directory.Exists(skillDirectory) ? skillDirectory : null;
+    }
+}

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaProjectFunctions.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaProjectFunctions.cs
@@ -1,0 +1,345 @@
+using System.ComponentModel;
+using System.Text;
+using OneWare.Essentials.Extensions;
+using OneWare.Essentials.Models;
+using OneWare.Essentials.Services;
+using OneWare.UniversalFpgaProjectSystem.Models;
+
+namespace OneWare.UniversalFpgaProjectSystem.Services.Ai;
+
+/// <summary>
+/// Chat functions that create, open and describe FPGA projects.
+/// </summary>
+public sealed class FpgaProjectFunctions(
+    FpgaAgentContext context,
+    FpgaService fpgaService,
+    UniversalFpgaProjectManager projectManager,
+    IPaths paths)
+{
+    /// <summary>
+    /// Creates the functions this group contributes to the chat.
+    /// </summary>
+    public IEnumerable<IOneWareAiFunction> CreateFunctions()
+    {
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_list_projects",
+            FriendlyName = "List FPGA projects",
+            DetailExtractor = FpgaFunctionDetail.Constant("loaded projects"),
+            Description = "Lists every FPGA project loaded in the IDE and marks the active one. Every other " +
+                          "fpga_* function acts on the active project, so call this first when unsure which " +
+                          "project is in scope.",
+            Handler = (Func<string>)ListProjects,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_set_active_project",
+            FriendlyName = "Select FPGA project",
+            DetailExtractor = FpgaFunctionDetail.FirstOf("project", "project"),
+            Description = "Makes a loaded FPGA project the active one, so the following fpga_* calls act on it. " +
+                          "Pass the project name or the path of its .fpgaproj file, as returned by " +
+                          "fpga_list_projects.",
+            Handler = (Func<string, string>)SetActiveProject,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_get_project_overview",
+            FriendlyName = "Read FPGA project",
+            DetailExtractor = FpgaFunctionDetail.Constant("project overview"),
+            Description = "Returns a snapshot of the active FPGA project: paths, selected board, toolchain, " +
+                          "loader, top entity, enabled pre-compile steps, test benches and files excluded from " +
+                          "compilation. Call this before changing anything.",
+            Handler = (Func<string>)GetOverview,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_create_project",
+            FriendlyName = "Create FPGA project",
+            DetailExtractor = FpgaFunctionDetail.AllOf("new project", "name", "toolchain"),
+            Description = "Creates a new FPGA project (.fpgaproj) in its own folder, loads it and makes it " +
+                          "active. Use fpga_list_toolchains first to get valid toolchain, loader and template " +
+                          "ids. Select the board afterwards with fpga_set_board.",
+            Handler = (Func<string, string?, string?, string?, string?, Task<string>>)CreateProjectAsync,
+            ConfirmationCheck = _ => "Create a new FPGA project? This creates a folder and a .fpgaproj file on disk.",
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_open_project",
+            FriendlyName = "Open FPGA project",
+            DetailExtractor = FpgaFunctionDetail.FirstOf("project file", "path"),
+            Description = "Loads an existing .fpgaproj file from disk into the IDE and makes it the active " +
+                          "project. Pass the absolute path of the .fpgaproj file.",
+            Handler = (Func<string, Task<string>>)OpenProjectAsync,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_save_project",
+            FriendlyName = "Save FPGA project",
+            DetailExtractor = FpgaFunctionDetail.Constant("save project"),
+            Description = "Writes the pending changes of the active FPGA project to its .fpgaproj file. The " +
+                          "other fpga_* functions already save, so this is only needed after a manual edit.",
+            Handler = (Func<Task<string>>)SaveProjectAsync,
+            RunOnUiThread = true
+        };
+    }
+
+    private string ListProjects()
+    {
+        return FpgaFunctionGuard.Run(() =>
+        {
+            var projects = context.GetProjects();
+
+            if (projects.Count == 0)
+                return "No FPGA project is loaded. Use fpga_create_project or fpga_open_project.";
+
+            var active = context.ProjectExplorerService.ActiveProject;
+            var builder = new StringBuilder();
+
+            builder.AppendLine($"{projects.Count} FPGA project(s) loaded:");
+
+            foreach (var project in projects)
+                builder.AppendLine(
+                    $"  - {project.Name}{(ReferenceEquals(project, active) ? " (active)" : "")} — {project.ProjectFilePath}");
+
+            return builder.ToString().TrimEnd();
+        });
+    }
+
+    private string SetActiveProject(
+        [Description("Name of the project, or the path of its .fpgaproj file.")]
+        string project)
+    {
+        return FpgaFunctionGuard.Run(() =>
+        {
+            var resolved = context.ResolveProject(project);
+            context.ProjectExplorerService.ActiveProject = resolved;
+
+            return $"'{resolved.Name}' is now the active project ({resolved.ProjectFilePath}).";
+        });
+    }
+
+    private string GetOverview()
+    {
+        return FpgaFunctionGuard.Run(() =>
+        {
+            var project = context.RequireProject();
+            var builder = new StringBuilder();
+
+            FpgaFunctionText.AppendField(builder, "Name", project.Name);
+            FpgaFunctionText.AppendField(builder, "ProjectFile", project.ProjectFilePath);
+            FpgaFunctionText.AppendField(builder, "RootFolder", project.RootFolderPath);
+            FpgaFunctionText.AppendField(builder, "Board", project.Board);
+            FpgaFunctionText.AppendField(builder, "Toolchain", DescribeToolchain(project.Toolchain));
+            FpgaFunctionText.AppendField(builder, "Loader", DescribeLoader(project.Loader));
+            FpgaFunctionText.AppendField(builder, "TopEntity", project.TopEntity);
+
+            FpgaFunctionText.AppendList(builder, "PreCompileSteps",
+                project.Properties.GetStringArray("preCompileSteps") ?? []);
+            FpgaFunctionText.AppendList(builder, "TestBenches",
+                project.Properties.GetStringArray("testBenches") ?? []);
+            FpgaFunctionText.AppendList(builder, "CompileExcluded",
+                project.Properties.GetStringArray("compileExcluded") ?? []);
+
+            return builder.ToString().TrimEnd();
+        });
+    }
+
+    private Task<string> CreateProjectAsync(
+        [Description("Name of the project. Used for the folder and the .fpgaproj file.")]
+        string name,
+        [Description("Directory the project folder is created in. Defaults to the ONE WARE Studio projects directory.")]
+        string? directory = null,
+        [Description("Id of the toolchain to use, as returned by fpga_list_toolchains.")]
+        string? toolchain = null,
+        [Description("Id of the loader to use, as returned by fpga_list_toolchains.")]
+        string? loader = null,
+        [Description("Name of the project template to fill the project with, as returned by fpga_list_toolchains.")]
+        string? template = null)
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var projectName = FpgaFunctionText.Require(name, nameof(name));
+
+            if (projectName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+                throw new FpgaAgentException($"'{projectName}' is not a valid project name.");
+
+            var parentFolder = string.IsNullOrWhiteSpace(directory) ? paths.ProjectsDirectory : directory.Trim();
+
+            if (!Directory.Exists(parentFolder))
+                throw new FpgaAgentException($"The directory '{parentFolder}' does not exist.");
+
+            var folder = Path.Combine(parentFolder, projectName);
+            var projectFile = Path.Combine(folder, projectName + UniversalFpgaProjectRoot.ProjectFileExtension);
+
+            if (File.Exists(projectFile))
+                throw new FpgaAgentException($"'{projectFile}' already exists. Open it with fpga_open_project.");
+
+            if (context.GetProjects().Any(x => x.RootFolderPath.EqualPaths(folder)))
+                throw new FpgaAgentException(
+                    $"Another FPGA project is already loaded from '{folder}'. A folder holds one project.");
+
+            // Resolve every id before touching the disk, so an invalid argument does not leave an
+            // empty folder or a half-configured project behind.
+            var selectedLoader = string.IsNullOrWhiteSpace(loader) ? null : ResolveLoader(loader);
+            var selectedToolchain = string.IsNullOrWhiteSpace(toolchain) ? null : ResolveToolchain(toolchain);
+            var selectedTemplate = string.IsNullOrWhiteSpace(template) ? null : ResolveTemplate(template);
+
+            Directory.CreateDirectory(folder);
+
+            var root = new UniversalFpgaProjectRoot(projectFile);
+            root.Properties.AddToStringArray("include", ["*.vhd", "*.vhdl", "*.v", "*.vcd", "vhdl_ls.toml"]);
+            root.Properties.AddToStringArray("exclude", ["build"]);
+
+            if (selectedLoader != null) root.Loader = selectedLoader.Id;
+
+            if (selectedToolchain != null)
+            {
+                root.Toolchain = selectedToolchain.Id;
+                selectedToolchain.OnProjectCreated(root);
+            }
+
+            await SaveAsync(root);
+
+            context.ProjectExplorerService.AddProject(root);
+
+            if (!context.ProjectExplorerService.Projects.Contains(root))
+                throw new FpgaAgentException(
+                    $"'{projectFile}' was written but could not be added to the project explorer.");
+
+            context.ProjectExplorerService.ActiveProject = root;
+
+            selectedTemplate?.FillTemplate(root);
+
+            await SaveAsync(root);
+
+            root.IsExpanded = true;
+
+            var builder = new StringBuilder();
+            builder.AppendLine($"Created and activated the FPGA project '{projectName}'.");
+            FpgaFunctionText.AppendField(builder, "ProjectFile", projectFile);
+            FpgaFunctionText.AppendField(builder, "Toolchain", DescribeToolchain(root.Toolchain));
+            FpgaFunctionText.AppendField(builder, "Loader", DescribeLoader(root.Loader));
+            FpgaFunctionText.AppendField(builder, "Template", selectedTemplate?.Name);
+            builder.Append("Select the board next with fpga_set_board.");
+
+            return builder.ToString();
+        });
+    }
+
+    private Task<string> OpenProjectAsync(
+        [Description("Absolute path of the .fpgaproj file to load.")]
+        string path)
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var projectFile = FpgaFunctionText.Require(path, nameof(path));
+
+            if (!File.Exists(projectFile))
+                throw new FpgaAgentException($"'{projectFile}' does not exist.");
+
+            if (!projectFile.EndsWith(UniversalFpgaProjectRoot.ProjectFileExtension, StringComparison.OrdinalIgnoreCase))
+                throw new FpgaAgentException(
+                    $"'{projectFile}' is not an FPGA project file ({UniversalFpgaProjectRoot.ProjectFileExtension}).");
+
+            // Loading an already loaded project would build a second root that the explorer rejects
+            // but that still becomes the active one, so every later change would go to a detached
+            // instance and be lost on the next save from the UI.
+            if (context.GetProjects().FirstOrDefault(x => x.ProjectFilePath.EqualPaths(projectFile)) is { } loadedRoot)
+            {
+                context.ProjectExplorerService.ActiveProject = loadedRoot;
+
+                return $"'{loadedRoot.Name}' was already loaded and is now the active project " +
+                       $"({loadedRoot.ProjectFilePath}).";
+            }
+
+            var loaded = await context.ProjectExplorerService
+                .LoadProjectAsync(projectFile, projectManager, true, true);
+
+            if (loaded is not UniversalFpgaProjectRoot root)
+                throw new FpgaAgentException($"'{projectFile}' could not be loaded as an FPGA project.");
+
+            return $"Loaded and activated '{root.Name}' ({root.ProjectFilePath}).";
+        });
+    }
+
+    private Task<string> SaveProjectAsync()
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+
+            await SaveAsync(project);
+
+            return $"Saved '{project.Name}' to {project.ProjectFilePath}.";
+        });
+    }
+
+    private async Task SaveAsync(UniversalFpgaProjectRoot project)
+    {
+        if (!await projectManager.SaveProjectAsync(project))
+            throw new FpgaAgentException($"'{project.Name}' could not be written to {project.ProjectFilePath}.");
+    }
+
+    private string? DescribeToolchain(string? id)
+    {
+        if (string.IsNullOrEmpty(id)) return null;
+
+        var toolchain = fpgaService.Toolchains.FirstOrDefault(x => x.Id == id);
+
+        return toolchain == null ? $"{id} (not installed)" : $"{toolchain.Name} ({toolchain.Id})";
+    }
+
+    private string? DescribeLoader(string? id)
+    {
+        if (string.IsNullOrEmpty(id)) return null;
+
+        var loader = fpgaService.Loaders.FirstOrDefault(x => x.Id == id);
+
+        return loader == null ? $"{id} (not installed)" : $"{loader.Name} ({loader.Id})";
+    }
+
+    private IFpgaToolchain ResolveToolchain(string idOrName)
+    {
+        var needle = idOrName.Trim();
+
+        return fpgaService.Toolchains.FirstOrDefault(x =>
+                   string.Equals(x.Id, needle, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(x.Name, needle, StringComparison.OrdinalIgnoreCase))
+               ?? throw new FpgaAgentException(
+                   $"'{idOrName}' is not an available toolchain. Available: " +
+                   $"{string.Join(", ", fpgaService.Toolchains.Select(x => x.Id))}.");
+    }
+
+    private IFpgaLoader ResolveLoader(string idOrName)
+    {
+        var needle = idOrName.Trim();
+
+        return fpgaService.Loaders.FirstOrDefault(x =>
+                   string.Equals(x.Id, needle, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(x.Name, needle, StringComparison.OrdinalIgnoreCase))
+               ?? throw new FpgaAgentException(
+                   $"'{idOrName}' is not an available loader. Available: " +
+                   $"{string.Join(", ", fpgaService.Loaders.Select(x => x.Id))}.");
+    }
+
+    private IFpgaProjectTemplate ResolveTemplate(string name)
+    {
+        var needle = name.Trim();
+
+        return fpgaService.Templates.FirstOrDefault(x =>
+                   string.Equals(x.Name, needle, StringComparison.OrdinalIgnoreCase))
+               ?? throw new FpgaAgentException(
+                   $"'{name}' is not an available project template. Available: " +
+                   $"{string.Join(", ", fpgaService.Templates.Select(x => x.Name))}.");
+    }
+}

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaSettingsFunctions.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaSettingsFunctions.cs
@@ -1,0 +1,438 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using System.Text.Json.Nodes;
+using Avalonia.Media;
+using OneWare.Essentials.Extensions;
+using OneWare.Essentials.Models;
+using OneWare.Essentials.Services;
+using OneWare.UniversalFpgaProjectSystem.Models;
+using OneWare.UniversalFpgaProjectSystem.Parser;
+
+namespace OneWare.UniversalFpgaProjectSystem.Services.Ai;
+
+/// <summary>
+/// Chat functions for the two kinds of settings an FPGA project has: the project settings that
+/// plugins register (stored in the .fpgaproj file) and the device settings of the selected board
+/// (stored in device-settings/&lt;board&gt;.deviceconf).
+/// </summary>
+public sealed class FpgaSettingsFunctions(
+    FpgaAgentContext context,
+    FpgaService fpgaService,
+    UniversalFpgaProjectManager projectManager,
+    IProjectSettingsService projectSettingsService)
+{
+    private const string PreCompileStepPrefix = "preCompileStep_";
+
+    /// <summary>
+    /// Creates the functions this group contributes to the chat.
+    /// </summary>
+    public IEnumerable<IOneWareAiFunction> CreateFunctions()
+    {
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_list_project_settings",
+            FriendlyName = "List FPGA project settings",
+            DetailExtractor = FpgaFunctionDetail.FirstOf("project settings", "category"),
+            Description = "Lists the settings of the active FPGA project that plugins registered, with their " +
+                          "key, category, current value and allowed values. These are the settings the project " +
+                          "settings dialog shows. Use fpga_set_project_setting to change one.",
+            Handler = (Func<string?, Task<string>>)ListProjectSettingsAsync,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_set_project_setting",
+            FriendlyName = "Set FPGA project setting",
+            DetailExtractor = FpgaFunctionDetail.AllOf("project setting", "key", "value"),
+            Description = "Changes one setting of the active FPGA project and saves the .fpgaproj file. Pass a " +
+                          "key from fpga_list_project_settings. For a pre-compile step " +
+                          "(key preCompileStep_<id>) pass true or false to enable or disable it.",
+            Handler = (Func<string, string, Task<string>>)SetProjectSettingAsync,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_list_device_settings",
+            FriendlyName = "List FPGA device settings",
+            DetailExtractor = FpgaFunctionDetail.Constant("device settings"),
+            Description = "Lists the device settings of the board selected for the active project, read from " +
+                          "device-settings/<board>.deviceconf. These describe the hardware itself, for example " +
+                          "the device part number or the programming mode.",
+            Handler = (Func<string>)ListDeviceSettings,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_set_device_setting",
+            FriendlyName = "Set FPGA device setting",
+            DetailExtractor = FpgaFunctionDetail.AllOf("device setting", "key", "value"),
+            Description = "Sets one device setting of the board selected for the active project and writes the " +
+                          ".deviceconf file. Pass an empty value to fall back to the board default.",
+            Handler = (Func<string, string, string>)SetDeviceSetting,
+            RunOnUiThread = true
+        };
+    }
+
+    private Task<string> ListProjectSettingsAsync(
+        [Description("Only list settings of this category. Omit to list every category.")]
+        string? category = null)
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+
+            var allCategories = projectSettingsService.GetProjectCategories().ToList();
+
+            List<string> categories;
+
+            if (string.IsNullOrWhiteSpace(category))
+            {
+                categories = allCategories;
+            }
+            else
+            {
+                var requested = allCategories.FirstOrDefault(x =>
+                                    string.Equals(x, category.Trim(), StringComparison.OrdinalIgnoreCase))
+                                ?? throw new FpgaAgentException(
+                                    $"'{category}' is not a settings category. Available: " +
+                                    $"{string.Join(", ", allCategories)}.");
+
+                categories = [requested];
+            }
+
+            var builder = new StringBuilder();
+            var found = 0;
+
+            foreach (var currentCategory in categories)
+            {
+                var settings = projectSettingsService.GetProjectSettingsList(currentCategory)
+                    .Where(x => x.ActivationFunction(project))
+                    .ToList();
+
+                if (settings.Count == 0) continue;
+
+                builder.AppendLine($"{currentCategory}:");
+
+                foreach (var setting in settings)
+                {
+                    var model = setting.HasFactory
+                        ? await setting.CreateSettingAsync(project)
+                        : setting.Setting;
+
+                    if (model == null) continue;
+
+                    found++;
+                    builder.AppendLine($"  - {setting.Key} ({DescribeType(model)})");
+                    builder.AppendLine($"      Title: {model.Title}");
+                    builder.AppendLine($"      Value: {DescribeValue(project, setting.Key, model)}");
+
+                    if (DescribeOptions(model) is { } options)
+                        builder.AppendLine($"      Allowed: {options}");
+                }
+            }
+
+            if (found == 0)
+                return string.IsNullOrWhiteSpace(category)
+                    ? "The active project has no registered settings."
+                    : $"No settings are registered in the category '{category}'. Available categories: " +
+                      $"{string.Join(", ", projectSettingsService.GetProjectCategories())}.";
+
+            return builder.ToString().TrimEnd();
+        });
+    }
+
+    private Task<string> SetProjectSettingAsync(
+        [Description("Key of the setting, as returned by fpga_list_project_settings.")]
+        string key,
+        [Description("The new value. For a checkbox pass true or false; for a list pass comma separated values.")]
+        string value)
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+            var settingKey = FpgaFunctionText.Require(key, nameof(key));
+
+            if (settingKey.StartsWith(PreCompileStepPrefix, StringComparison.OrdinalIgnoreCase))
+                return await SetPreCompileStepAsync(project, settingKey, value);
+
+            var definition = projectSettingsService.GetProjectSettingsList()
+                                 .FirstOrDefault(x => string.Equals(x.Key, settingKey, StringComparison.Ordinal))
+                             ?? throw new FpgaAgentException(
+                                 $"'{key}' is not a registered project setting. Call fpga_list_project_settings " +
+                                 "for the available keys.");
+
+            if (!definition.ActivationFunction(project))
+                throw new FpgaAgentException(
+                    $"The setting '{settingKey}' does not apply to '{project.Name}' with its current toolchain.");
+
+            var model = definition.HasFactory
+                ? await definition.CreateSettingAsync(project)
+                : definition.Setting;
+
+            if (model == null)
+                throw new FpgaAgentException($"The setting '{settingKey}' could not be read.");
+
+            project.Properties.SetNode(settingKey, ConvertValue(model, settingKey, value));
+
+            await SaveAsync(project);
+            await context.ProjectExplorerService.ReloadProjectAsync(project);
+
+            return $"Set '{settingKey}' to '{value}' in '{project.Name}'.";
+        });
+    }
+
+    private async Task<string> SetPreCompileStepAsync(UniversalFpgaProjectRoot project, string key, string value)
+    {
+        var requestedId = key[PreCompileStepPrefix.Length..];
+        var enable = FpgaFunctionText.ParseBool(value, nameof(value));
+
+        // The settings dialog compares the stored ids case-sensitively, so storing the caller's
+        // spelling instead of the registered one would make it drop the entry on its next save.
+        var stepId = fpgaService.PreCompileSteps
+                         .FirstOrDefault(x => string.Equals(x.Id, requestedId, StringComparison.OrdinalIgnoreCase))
+                         ?.Id
+                     ?? throw new FpgaAgentException(
+                         $"'{requestedId}' is not a registered pre-compile step. Available: " +
+                         $"{string.Join(", ", fpgaService.PreCompileSteps.Select(x => x.Id))}.");
+
+        var steps = (project.Properties.GetStringArray("preCompileSteps") ?? []).ToList();
+
+        steps.RemoveAll(x => string.Equals(x, stepId, StringComparison.OrdinalIgnoreCase));
+
+        if (enable) steps.Add(stepId);
+
+        project.Properties.SetNode("preCompileSteps",
+            new JsonArray(steps.Select(x => (JsonNode?)JsonValue.Create(x)).ToArray()));
+
+        await SaveAsync(project);
+        await context.ProjectExplorerService.ReloadProjectAsync(project);
+
+        return $"{(enable ? "Enabled" : "Disabled")} the pre-compile step '{stepId}' for '{project.Name}'.";
+    }
+
+    private string ListDeviceSettings()
+    {
+        return FpgaFunctionGuard.Run(() =>
+        {
+            var project = context.RequireProject();
+            var board = RequireBoard(project);
+
+            var stored = FpgaSettingsParser.LoadSettings(project, board);
+            var defaults = GetBoardDefaults(board);
+
+            var keys = stored.Keys.Concat(defaults.Keys)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .ToList();
+
+            if (keys.Count == 0)
+                return $"The board '{board}' has no device settings.";
+
+            var builder = new StringBuilder();
+            builder.AppendLine($"Device settings of board '{board}':");
+
+            foreach (var settingKey in keys)
+            {
+                var hasStored = stored.TryGetValue(settingKey, out var storedValue);
+                var hasDefault = defaults.TryGetValue(settingKey, out var defaultValue);
+
+                var origin = hasStored
+                    ? hasDefault && storedValue == defaultValue ? "default" : "project"
+                    : "default";
+
+                builder.AppendLine(
+                    $"  - {settingKey} = {(hasStored ? storedValue : defaultValue)} ({origin})");
+            }
+
+            return builder.ToString().TrimEnd();
+        });
+    }
+
+    private string SetDeviceSetting(
+        [Description("Key of the device setting, as returned by fpga_list_device_settings.")]
+        string key,
+        [Description("The new value. Pass an empty string to remove the entry and use the board default.")]
+        string value)
+    {
+        return FpgaFunctionGuard.Run(() =>
+        {
+            var project = context.RequireProject();
+            var board = RequireBoard(project);
+            var settingKey = FpgaFunctionText.Require(key, nameof(key));
+
+            var settings = FpgaSettingsParser.LoadSettings(project, board);
+            var defaults = GetBoardDefaults(board);
+
+            if (!settings.ContainsKey(settingKey) && !defaults.ContainsKey(settingKey))
+                throw new FpgaAgentException(
+                    $"'{settingKey}' is not a device setting of board '{board}'. Call " +
+                    "fpga_list_device_settings for the available keys.");
+
+            // An empty value is dropped by the parser, which is exactly the "use the default" case.
+            settings[settingKey] = value;
+
+            if (!FpgaSettingsParser.SaveSettings(project, board, settings))
+                throw new FpgaAgentException($"The device settings of board '{board}' could not be written.");
+
+            return string.IsNullOrEmpty(value)
+                ? $"Removed '{settingKey}' from the device settings of '{board}', so its default applies again."
+                : $"Set '{settingKey}' to '{value}' for board '{board}'.";
+        });
+    }
+
+    private string RequireBoard(UniversalFpgaProjectRoot project)
+    {
+        if (string.IsNullOrEmpty(project.Board))
+            throw new FpgaAgentException(
+                "No board is selected. Call fpga_list_toolchains and fpga_set_board first.");
+
+        return project.Board;
+    }
+
+    private IReadOnlyDictionary<string, string> GetBoardDefaults(string board)
+    {
+        var package = fpgaService.FpgaPackages.FirstOrDefault(x => x.Name == board);
+
+        if (package == null) return new Dictionary<string, string>();
+
+        try
+        {
+            return package.LoadFpga().Properties;
+        }
+        catch (Exception e)
+        {
+            throw new FpgaAgentException($"The board '{board}' could not be loaded: {e.Message}", e);
+        }
+    }
+
+    private async Task SaveAsync(UniversalFpgaProjectRoot project)
+    {
+        if (!await projectManager.SaveProjectAsync(project))
+            throw new FpgaAgentException($"'{project.Name}' could not be saved.");
+    }
+
+    private static string DescribeType(TitledSetting setting)
+    {
+        return setting switch
+        {
+            CheckBoxSetting => "boolean",
+            SliderSetting => "number",
+            ListBoxSetting => "list",
+            ColorSetting => "color",
+            FolderPathSetting => "folder path",
+            FilePathSetting => "file path",
+            ComboBoxSetting or AdvancedComboBoxSetting or ComboListBoxSetting => "choice",
+            _ => "text"
+        };
+    }
+
+    private static string DescribeValue(UniversalFpgaProjectRoot project, string key, TitledSetting setting)
+    {
+        // A pre-compile step has no property of its own; its state lives in the shared array.
+        if (key.StartsWith(PreCompileStepPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            var stepId = key[PreCompileStepPrefix.Length..];
+            var enabled = (project.Properties.GetStringArray("preCompileSteps") ?? [])
+                .Any(x => string.Equals(x, stepId, StringComparison.OrdinalIgnoreCase));
+
+            return enabled.ToString();
+        }
+
+        if (project.Properties.GetNode(key) is { } node)
+            return node is JsonArray array
+                ? string.Join(", ", array.Select(x => x?.ToString()))
+                : node.ToString();
+
+        return $"{setting.DefaultValue} (default)";
+    }
+
+    private static string? DescribeOptions(TitledSetting setting)
+    {
+        return setting switch
+        {
+            CheckBoxSetting => "true, false",
+            ComboBoxSetting combo => string.Join(", ", combo.Options.Select(x => x.ToString())),
+            AdvancedComboBoxSetting advanced => string.Join(", ", advanced.Options.Select(x => x.Value.ToString())),
+            ComboListBoxSetting comboList => string.Join(", ", comboList.Options),
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Converts a text argument into the node the project settings dialog would write for the same
+    /// setting, so both writers stay interchangeable.
+    /// </summary>
+    private static JsonNode? ConvertValue(TitledSetting setting, string key, string value)
+    {
+        switch (setting)
+        {
+            case CheckBoxSetting:
+                return JsonValue.Create(FpgaFunctionText.ParseBool(value, key));
+
+            case SliderSetting:
+                if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var number))
+                    throw new FpgaAgentException($"'{value}' is not a number for the setting '{key}'.");
+                return JsonValue.Create(number);
+
+            case ColorSetting:
+                if (!Color.TryParse(value, out _))
+                    throw new FpgaAgentException($"'{value}' is not a color for the setting '{key}'.");
+                return JsonValue.Create(value);
+
+            case FolderPathSetting or FilePathSetting:
+                return JsonValue.Create(value.ToUnixPath());
+
+            case ListBoxSetting:
+                return CreateArray(SplitItems(value), key);
+
+            case ComboListBoxSetting comboList:
+                return CreateArray(
+                    SplitItems(value).Select(x => RequireOption(comboList.Options, x, key)), key);
+
+            case ComboBoxSetting combo:
+                return JsonValue.Create(RequireOption(combo.Options.Select(x => x.ToString()), value, key));
+
+            case AdvancedComboBoxSetting advanced:
+                return JsonValue.Create(
+                    RequireOption(advanced.Options.Select(x => x.Value.ToString()), value, key));
+
+            default:
+                return JsonValue.Create(value);
+        }
+    }
+
+    private static string[] SplitItems(string value)
+    {
+        return value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    /// <summary>
+    /// Builds a string array node. Path-like keys are normalized to forward slashes, because the
+    /// glob matching compares patterns verbatim and would never match a Windows style pattern.
+    /// </summary>
+    private static JsonArray CreateArray(IEnumerable<string> items, string key)
+    {
+        var normalize = key is "include" or "exclude" or "compileExcluded" or "testBenches";
+
+        return new JsonArray(items
+            .Select(x => (JsonNode?)JsonValue.Create(normalize ? x.ToUnixPath() : x))
+            .ToArray());
+    }
+
+    /// <summary>
+    /// Returns the allowed option that matches <paramref name="value"/>, so the stored value keeps
+    /// the exact casing the setting declares.
+    /// </summary>
+    private static string RequireOption(IEnumerable<string?> options, string value, string key)
+    {
+        var allowed = options.Where(x => x != null).Select(x => x!).ToList();
+
+        return allowed.FirstOrDefault(x => string.Equals(x, value, StringComparison.OrdinalIgnoreCase))
+               ?? throw new FpgaAgentException(
+                   $"'{value}' is not allowed for the setting '{key}'. Allowed: {string.Join(", ", allowed)}.");
+    }
+}

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaSimulationFunctions.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaSimulationFunctions.cs
@@ -1,0 +1,199 @@
+using System.ComponentModel;
+using System.Text;
+using OneWare.Essentials.Models;
+using OneWare.UniversalFpgaProjectSystem.Context;
+
+namespace OneWare.UniversalFpgaProjectSystem.Services.Ai;
+
+/// <summary>
+/// Chat functions that configure and run the simulation of a test bench.
+/// </summary>
+/// <remarks>
+/// The per-test-bench configuration lives in a <c>.tbconf</c> file next to the test bench, not in
+/// the project file, so these functions read and write that file directly.
+/// </remarks>
+public sealed class FpgaSimulationFunctions(FpgaAgentContext context, FpgaService fpgaService)
+{
+    /// <summary>
+    /// Creates the functions this group contributes to the chat.
+    /// </summary>
+    public IEnumerable<IOneWareAiFunction> CreateFunctions()
+    {
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_get_testbench_config",
+            FriendlyName = "Read test bench config",
+            DetailExtractor = FpgaFunctionDetail.FirstOf("test bench config", "path"),
+            Description = "Returns the simulation configuration of a test bench, stored in the .tbconf file " +
+                          "next to it: the selected simulator and its options, for example TopModule or " +
+                          "VerilatorArguments.",
+            Handler = (Func<string, Task<string>>)GetTestBenchConfigAsync,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_set_testbench_simulator",
+            FriendlyName = "Select test bench simulator",
+            DetailExtractor = FpgaFunctionDetail.AllOf("simulator", "path", "simulator"),
+            Description = "Selects the simulator used for a test bench and writes it to the .tbconf file. Pass " +
+                          "a simulator name from fpga_list_toolchains. The file must already be marked as a " +
+                          "test bench with fpga_set_testbench.",
+            Handler = (Func<string, string, Task<string>>)SetTestBenchSimulatorAsync,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_set_testbench_option",
+            FriendlyName = "Set test bench option",
+            DetailExtractor = FpgaFunctionDetail.AllOf("test bench option", "path", "key", "value"),
+            Description = "Sets one simulator option of a test bench in its .tbconf file. Common keys are " +
+                          "TopModule, VerilatorArguments, VerilatorRuntimeArguments, IcarusVerilogArguments and " +
+                          "WaveOutputFormat. Pass an empty value to remove the option.",
+            Handler = (Func<string, string, string, Task<string>>)SetTestBenchOptionAsync,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_run_simulation",
+            FriendlyName = "Run FPGA simulation",
+            DetailExtractor = FpgaFunctionDetail.FirstOf("simulation", "path"),
+            Description = "Runs the simulator configured for a test bench. The simulator output appears in the " +
+                          "Output panel; this function reports whether the run succeeded. Select the simulator " +
+                          "with fpga_set_testbench_simulator first.",
+            Handler = (Func<string, Task<string>>)RunSimulationAsync,
+            ConfirmationCheck = _ => "Run the test bench simulation? This runs the external simulator.",
+            RunOnUiThread = true
+        };
+    }
+
+    private Task<string> GetTestBenchConfigAsync(
+        [Description("Path of the test bench file, relative to the project root or absolute.")]
+        string path)
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+            var file = context.RequireFile(project, path);
+            var testBenchContext = await TestBenchContextManager.LoadContextAsync(file.FullPath);
+
+            var builder = new StringBuilder();
+            FpgaFunctionText.AppendField(builder, "File", file.RelativePath);
+            FpgaFunctionText.AppendField(builder, "IsTestBench", project.IsTestBench(file.RelativePath));
+            FpgaFunctionText.AppendField(builder, "Simulator", testBenchContext.Simulator);
+            FpgaFunctionText.AppendList(builder, "Options",
+                testBenchContext.Properties
+                    .Where(x => x.Key != "simulator")
+                    .Select(x => $"{x.Key} = {x.Value}"),
+                "(none — the simulator defaults apply)");
+
+            return builder.ToString().TrimEnd();
+        });
+    }
+
+    private Task<string> SetTestBenchSimulatorAsync(
+        [Description("Path of the test bench file, relative to the project root or absolute.")]
+        string path,
+        [Description("Name of the simulator, as returned by fpga_list_toolchains.")]
+        string simulator)
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+            var file = context.RequireFile(project, path);
+            var needle = FpgaFunctionText.Require(simulator, nameof(simulator));
+
+            var selected = ResolveSimulator(needle);
+
+            var testBenchContext = await TestBenchContextManager.LoadContextAsync(file.FullPath);
+            testBenchContext.Simulator = selected.Name;
+
+            await SaveContextAsync(testBenchContext, file.RelativePath);
+
+            return project.IsTestBench(file.RelativePath)
+                ? $"'{file.RelativePath}' is simulated with {selected.Name}."
+                : $"'{file.RelativePath}' is simulated with {selected.Name}. It is not marked as a test bench " +
+                  "yet — call fpga_set_testbench to show the simulation toolbar for it.";
+        });
+    }
+
+    private Task<string> SetTestBenchOptionAsync(
+        [Description("Path of the test bench file, relative to the project root or absolute.")]
+        string path,
+        [Description("Name of the option, for example TopModule or VerilatorArguments.")]
+        string key,
+        [Description("The new value. Pass an empty string to remove the option.")]
+        string value)
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+            var file = context.RequireFile(project, path);
+            var optionKey = FpgaFunctionText.Require(key, nameof(key));
+
+            if (string.Equals(optionKey, "simulator", StringComparison.OrdinalIgnoreCase))
+                throw new FpgaAgentException("Use fpga_set_testbench_simulator to change the simulator.");
+
+            var testBenchContext = await TestBenchContextManager.LoadContextAsync(file.FullPath);
+
+            if (string.IsNullOrEmpty(value))
+                testBenchContext.RemoveBenchProperty(optionKey);
+            else
+                testBenchContext.SetBenchProperty(optionKey, value);
+
+            await SaveContextAsync(testBenchContext, file.RelativePath);
+
+            return string.IsNullOrEmpty(value)
+                ? $"Removed '{optionKey}' from the configuration of '{file.RelativePath}'."
+                : $"Set '{optionKey}' to '{value}' for '{file.RelativePath}'.";
+        });
+    }
+
+    private Task<string> RunSimulationAsync(
+        [Description("Path of the test bench file, relative to the project root or absolute.")]
+        string path)
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+            var file = context.RequireFile(project, path);
+
+            var testBenchContext = await TestBenchContextManager.LoadContextAsync(file.FullPath);
+
+            if (string.IsNullOrEmpty(testBenchContext.Simulator))
+                throw new FpgaAgentException(
+                    $"No simulator is selected for '{file.RelativePath}'. Call fpga_set_testbench_simulator " +
+                    "first.");
+
+            var simulator = ResolveSimulator(testBenchContext.Simulator);
+
+            await context.ProjectExplorerService.SaveOpenFilesForProjectAsync(project);
+
+            var success = await simulator.SimulateAsync(file.FullPath);
+
+            return success
+                ? $"Simulated '{file.RelativePath}' successfully with {simulator.Name}."
+                : $"Simulating '{file.RelativePath}' with {simulator.Name} failed. Read the Output panel for " +
+                  "the reported error.";
+        });
+    }
+
+    private IFpgaSimulator ResolveSimulator(string name)
+    {
+        var needle = name.Trim();
+
+        return fpgaService.Simulators.FirstOrDefault(x =>
+                   string.Equals(x.Name, needle, StringComparison.OrdinalIgnoreCase))
+               ?? throw new FpgaAgentException(
+                   $"'{name}' is not an available simulator. Available: " +
+                   $"{string.Join(", ", fpgaService.Simulators.Select(x => x.Name))}.");
+    }
+
+    private static async Task SaveContextAsync(TestBenchContext testBenchContext, string relativePath)
+    {
+        if (!await TestBenchContextManager.SaveContextAsync(testBenchContext))
+            throw new FpgaAgentException($"The configuration of '{relativePath}' could not be written.");
+    }
+}

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaToolchainFunctions.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaToolchainFunctions.cs
@@ -194,8 +194,8 @@ public sealed class FpgaToolchainFunctions(
 
             await SaveAsync(project);
 
-            return $"'{project.Name}' now targets the board {selected.Name}. Assign the pins in the pin planner " +
-                   "before compiling if the design uses IO.";
+            return $"'{project.Name}' now targets the board {selected.Name}. Assign the pins in the constraint " +
+                   "editor before compiling if the design uses IO.";
         });
     }
 

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaToolchainFunctions.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/Ai/FpgaToolchainFunctions.cs
@@ -1,0 +1,283 @@
+using System.ComponentModel;
+using System.Text;
+using OneWare.Essentials.Models;
+using OneWare.UniversalFpgaProjectSystem.Models;
+
+namespace OneWare.UniversalFpgaProjectSystem.Services.Ai;
+
+/// <summary>
+/// Chat functions that select the FPGA hardware and toolchain of a project and run a compile.
+/// </summary>
+public sealed class FpgaToolchainFunctions(
+    FpgaAgentContext context,
+    FpgaService fpgaService,
+    UniversalFpgaProjectManager projectManager)
+{
+    /// <summary>
+    /// Creates the functions this group contributes to the chat.
+    /// </summary>
+    public IEnumerable<IOneWareAiFunction> CreateFunctions()
+    {
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_list_toolchains",
+            FriendlyName = "List FPGA toolchains",
+            DetailExtractor = FpgaFunctionDetail.Constant("available hardware and tools"),
+            Description = "Lists everything that can be selected for an FPGA project: toolchains, loaders, " +
+                          "simulators, boards, project templates and pre-compile steps, each with the exact id " +
+                          "to pass to fpga_set_toolchain, fpga_set_loader and fpga_set_board.",
+            Handler = (Func<string>)ListToolchains,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_set_toolchain",
+            FriendlyName = "Select FPGA toolchain",
+            DetailExtractor = FpgaFunctionDetail.FirstOf("toolchain", "toolchain"),
+            Description = "Selects the toolchain used to compile the active FPGA project. Pass an id from " +
+                          "fpga_list_toolchains. This also lets the toolchain write its default project settings.",
+            Handler = (Func<string, Task<string>>)SetToolchainAsync,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_set_loader",
+            FriendlyName = "Select FPGA loader",
+            DetailExtractor = FpgaFunctionDetail.FirstOf("loader", "loader"),
+            Description = "Selects the loader (programmer) used to configure the FPGA or write its FLASH " +
+                          "memory. Pass an id from fpga_list_toolchains.",
+            Handler = (Func<string, Task<string>>)SetLoaderAsync,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_set_board",
+            FriendlyName = "Select FPGA board",
+            DetailExtractor = FpgaFunctionDetail.FirstOf("board", "board"),
+            Description = "Selects the FPGA board of the active project. A board must be selected before " +
+                          "fpga_compile works. Pass a board name from fpga_list_toolchains.",
+            Handler = (Func<string, Task<string>>)SetBoardAsync,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_list_top_entities",
+            FriendlyName = "List FPGA top entities",
+            DetailExtractor = FpgaFunctionDetail.Constant("top entities"),
+            Description = "Scans the HDL sources of the active project and returns every entity or module that " +
+                          "could serve as the top level, together with the file it is declared in. Files " +
+                          "excluded from compilation and test benches are skipped.",
+            Handler = (Func<Task<string>>)ListTopEntitiesAsync,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_set_top_entity",
+            FriendlyName = "Set FPGA top entity",
+            DetailExtractor = FpgaFunctionDetail.FirstOf("top entity", "topEntity"),
+            Description = "Sets the top level entity or module the toolchain synthesizes. Pass a name from " +
+                          "fpga_list_top_entities.",
+            Handler = (Func<string, Task<string>>)SetTopEntityAsync,
+            RunOnUiThread = true
+        };
+
+        yield return new OneWareAiFunction
+        {
+            Name = "fpga_compile",
+            FriendlyName = "Compile FPGA project",
+            DetailExtractor = FpgaFunctionDetail.Constant("compile"),
+            Description = "Compiles the active FPGA project with its selected toolchain: saves the open files, " +
+                          "runs the enabled pre-compile steps and then synthesis, place & route and bitstream " +
+                          "generation. The build stops at the first tool that fails. The tool output appears in " +
+                          "the Output panel; this function reports success or failure.",
+            Handler = (Func<Task<string>>)CompileAsync,
+            ConfirmationCheck = _ => "Compile the active FPGA project? This runs the external toolchain.",
+            RunOnUiThread = true
+        };
+    }
+
+    private string ListToolchains()
+    {
+        return FpgaFunctionGuard.Run(() =>
+        {
+            var builder = new StringBuilder();
+
+            FpgaFunctionText.AppendList(builder, "Toolchains",
+                fpgaService.Toolchains.Select(x => $"{x.Id} — {x.Name}"),
+                "(none — install a toolchain plugin such as OSS CAD Suite)");
+            FpgaFunctionText.AppendList(builder, "Loaders",
+                fpgaService.Loaders.Select(x => $"{x.Id} — {x.Name}"));
+            FpgaFunctionText.AppendList(builder, "Simulators",
+                fpgaService.Simulators.Select(x => x.Name));
+            FpgaFunctionText.AppendList(builder, "Boards",
+                fpgaService.FpgaPackages.Select(x => x.Name),
+                "(none — install a hardware package)");
+            FpgaFunctionText.AppendList(builder, "ProjectTemplates",
+                fpgaService.Templates.Select(x => x.Name));
+            FpgaFunctionText.AppendList(builder, "PreCompileSteps",
+                fpgaService.PreCompileSteps.Select(x => $"{x.Id} — {x.Name}"));
+
+            return builder.ToString().TrimEnd();
+        });
+    }
+
+    private Task<string> SetToolchainAsync(
+        [Description("Id of the toolchain, as returned by fpga_list_toolchains.")]
+        string toolchain)
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+            var needle = FpgaFunctionText.Require(toolchain, nameof(toolchain));
+
+            var selected = fpgaService.Toolchains.FirstOrDefault(x =>
+                               string.Equals(x.Id, needle, StringComparison.OrdinalIgnoreCase) ||
+                               string.Equals(x.Name, needle, StringComparison.OrdinalIgnoreCase))
+                           ?? throw new FpgaAgentException(
+                               $"'{toolchain}' is not an available toolchain. Available: " +
+                               $"{string.Join(", ", fpgaService.Toolchains.Select(x => x.Id))}.");
+
+            project.Toolchain = selected.Id;
+            selected.OnProjectCreated(project);
+
+            await SaveAsync(project);
+
+            return $"'{project.Name}' now uses the toolchain {selected.Name} ({selected.Id}).";
+        });
+    }
+
+    private Task<string> SetLoaderAsync(
+        [Description("Id of the loader, as returned by fpga_list_toolchains.")]
+        string loader)
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+            var needle = FpgaFunctionText.Require(loader, nameof(loader));
+
+            var selected = fpgaService.Loaders.FirstOrDefault(x =>
+                               string.Equals(x.Id, needle, StringComparison.OrdinalIgnoreCase) ||
+                               string.Equals(x.Name, needle, StringComparison.OrdinalIgnoreCase))
+                           ?? throw new FpgaAgentException(
+                               $"'{loader}' is not an available loader. Available: " +
+                               $"{string.Join(", ", fpgaService.Loaders.Select(x => x.Id))}.");
+
+            project.Loader = selected.Id;
+
+            await SaveAsync(project);
+
+            return $"'{project.Name}' now uses the loader {selected.Name} ({selected.Id}).";
+        });
+    }
+
+    private Task<string> SetBoardAsync(
+        [Description("Name of the board, as returned by fpga_list_toolchains.")]
+        string board)
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+            var needle = FpgaFunctionText.Require(board, nameof(board));
+
+            var selected = fpgaService.FpgaPackages.FirstOrDefault(x =>
+                               string.Equals(x.Name, needle, StringComparison.OrdinalIgnoreCase))
+                           ?? throw new FpgaAgentException(
+                               $"'{board}' is not an available board. Available: " +
+                               $"{string.Join(", ", fpgaService.FpgaPackages.Select(x => x.Name))}.");
+
+            project.Board = selected.Name;
+
+            await SaveAsync(project);
+
+            return $"'{project.Name}' now targets the board {selected.Name}. Assign the pins in the pin planner " +
+                   "before compiling if the design uses IO.";
+        });
+    }
+
+    private Task<string> ListTopEntitiesAsync()
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+            var entities = await fpgaService.GetAllTopEntitiesAsync(project);
+
+            if (entities.Count == 0)
+                return "No top entity was found. Check that the project contains HDL sources and that the " +
+                       "language plugin for them is installed.";
+
+            var builder = new StringBuilder();
+            FpgaFunctionText.AppendField(builder, "Current", project.TopEntity);
+            FpgaFunctionText.AppendList(builder, "Candidates",
+                entities.Select(x => $"{x.TopEntity} — {x.File.RelativePath}"));
+
+            return builder.ToString().TrimEnd();
+        });
+    }
+
+    private Task<string> SetTopEntityAsync(
+        [Description("Name of the entity or module, as returned by fpga_list_top_entities.")]
+        string topEntity)
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+            var needle = FpgaFunctionText.Require(topEntity, nameof(topEntity));
+
+            var entities = await fpgaService.GetAllTopEntitiesAsync(project);
+
+            var match = entities.FirstOrDefault(x =>
+                string.Equals(x.TopEntity, needle, StringComparison.OrdinalIgnoreCase));
+
+            if (match == null && entities.Count > 0)
+                throw new FpgaAgentException(
+                    $"'{topEntity}' is not one of the entities found in the project. Available: " +
+                    $"{string.Join(", ", entities.Select(x => x.TopEntity))}.");
+
+            project.TopEntity = match?.TopEntity ?? needle;
+            project.TopEntityFilePath = match?.File.RelativePath;
+
+            await SaveAsync(project);
+
+            return match == null
+                ? $"Set the top entity of '{project.Name}' to '{needle}'. No HDL file declaring it was found, so " +
+                  "verify the name."
+                : $"Set the top entity of '{project.Name}' to '{match.TopEntity}' ({match.File.RelativePath}).";
+        });
+    }
+
+    private Task<string> CompileAsync()
+    {
+        return FpgaFunctionGuard.RunAsync(async () =>
+        {
+            var project = context.RequireProject();
+
+            if (string.IsNullOrEmpty(project.Toolchain))
+                throw new FpgaAgentException(
+                    "No toolchain is selected. Call fpga_list_toolchains and fpga_set_toolchain first.");
+
+            if (string.IsNullOrEmpty(project.Board))
+                throw new FpgaAgentException(
+                    "No board is selected. Call fpga_list_toolchains and fpga_set_board first.");
+
+            await context.ProjectExplorerService.SaveOpenFilesForProjectAsync(project);
+
+            var success = await fpgaService.RunToolchainAsync(project);
+
+            return success
+                ? $"Compiled '{project.Name}' successfully with {project.Toolchain}."
+                : $"Compiling '{project.Name}' failed. Read the Output panel for the tool that reported the " +
+                  "error; the build stops at the first failing stage, so the first error is the relevant one.";
+        });
+    }
+
+    private async Task SaveAsync(UniversalFpgaProjectRoot project)
+    {
+        if (!await projectManager.SaveProjectAsync(project))
+            throw new FpgaAgentException($"'{project.Name}' could not be saved.");
+    }
+}

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/FpgaService.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/FpgaService.cs
@@ -319,7 +319,7 @@ public class FpgaService
                 if (fpgaPackage == null)
                 {
                     ContainerLocator.Container.Resolve<ILogger>()
-                        .Warning($"No FPGA Selected (or {name} not found). Open Pin Planner first");
+                        .Warning($"No FPGA Selected (or {name} not found). Open Constraints first");
                     return false;
                 }
 

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/FpgaService.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/FpgaService.cs
@@ -336,8 +336,7 @@ public class FpgaService
                     return false;
             }
 
-            await toolchain.CompileAsync(project, fpgaModel);
-            return true;
+            return await toolchain.CompileAsync(project, fpgaModel);
         }
         catch (Exception e)
         {

--- a/src/OneWare.UniversalFpgaProjectSystem/Services/IFpgaToolchain.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/Services/IFpgaToolchain.cs
@@ -10,7 +10,7 @@ public interface IFpgaToolchain
     public string Name { get; }
 
     /// <summary>
-    /// Per-pin properties this toolchain wants to expose and persist in the pin planner.
+    /// Per-pin properties this toolchain wants to expose and persist in the constraint editor.
     /// Override in toolchain implementations to declare properties such as IO Voltage.
     /// </summary>
     public IEnumerable<PinPropertyDefinition> PinProperties => [];

--- a/src/OneWare.UniversalFpgaProjectSystem/Skills/fpga-project-file/SKILL.md
+++ b/src/OneWare.UniversalFpgaProjectSystem/Skills/fpga-project-file/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: fpga-project-file
+description: Format of a ONE WARE Studio .fpgaproj file and of the .deviceconf and .tbconf files next to it — which key means what, which ones have a dedicated fpga_* function, and which ones may only be edited by hand.
+---
+
+# The .fpgaproj file and its companions
+
+An FPGA project is a folder containing one `<name>.fpgaproj` file. That file is plain JSON and is
+the single source of truth for the project; the folder layout carries no meaning beyond it.
+
+Prefer the `fpga_*` functions over editing these files. They validate the value against what is
+actually installed, keep the in-memory project model in sync, and save. Hand-editing a project file
+that the IDE has open loses the edit on the next save.
+
+## .fpgaproj
+
+```jsonc
+{
+  "include": ["*.vhd", "*.vhdl", "*.v", "*.vcd", "vhdl_ls.toml"],
+  "exclude": ["build"],
+  "toolchain": "yosys",
+  "loader": "openFpgaLoader",
+  "board": "MyBoard",
+  "topEntity": "top",
+  "compileExcluded": ["src/old_top.v"],
+  "testBenches": ["sim/top_tb.v"],
+  "preCompileSteps": ["someStepId"]
+}
+```
+
+| Key | Meaning | Function |
+| --- | --- | --- |
+| `include` | Glob patterns or relative paths that make up the project file set. It must list at least one pattern — an empty or missing array includes **no** file, so the project appears empty and nothing reaches the toolchain. | `fpga_set_project_setting` (`include`) |
+| `exclude` | Patterns removed from the file set again. Excluded files are invisible to the IDE. | `fpga_set_project_setting` (`exclude`) |
+| `toolchain` | Id of the compile toolchain. | `fpga_set_toolchain` |
+| `loader` | Id of the programmer used to configure the FPGA or write its FLASH. | `fpga_set_loader` |
+| `board` | Name of the selected board. | `fpga_set_board` |
+| `topEntity` | Name of the top level entity/module for synthesis. | `fpga_set_top_entity` |
+| `compileExcluded` | Relative paths kept in the project but not passed to synthesis. | `fpga_set_compile_excluded` |
+| `testBenches` | Relative paths marked as test benches. | `fpga_set_testbench` |
+| `preCompileSteps` | Ids of the pre-compile steps that run before synthesis. | `fpga_set_project_setting` (`preCompileStep_<id>`) |
+
+Everything else in the file was registered by a plugin — typically the toolchain — and appears in
+`fpga_list_project_settings` with its key, type and allowed values. `vhdlStandard` is one example;
+which keys exist depends on the selected toolchain, so list them instead of assuming.
+
+Notes on the format:
+
+- Paths are relative to the project folder and use `/` as separator, on every platform. A pattern
+  written with `\` never matches.
+- `include`/`exclude` decide what the IDE sees at all. `compileExcluded` decides what the
+  *synthesizer* sees. They are not interchangeable: a file removed via `exclude` disappears from
+  the project explorer, a `compileExcluded` file stays visible and greyed out.
+- `fpga` was the old key for `board`. Old files are migrated automatically; write `board`.
+- `Toolchain`, `Loader` and `VHDL_Standard` (capitalised) are likewise legacy spellings that are
+  migrated to `toolchain`, `loader` and `vhdlStandard`.
+
+## device-settings/&lt;board&gt;.deviceconf
+
+A flat JSON object of string properties describing the selected board, for example a device part
+number or a programming mode:
+
+```json
+{
+  "device": "iCE40UP5K",
+  "package": "sg48"
+}
+```
+
+The defaults come from the installed hardware package; the file only needs to carry the values that
+differ. An entry with an empty value is dropped on save, which is how "use the board default" is
+expressed — `fpga_set_device_setting` with an empty value does exactly that.
+
+The file is only meaningful once a board is selected, and it is per board: switching the board
+switches to a different `.deviceconf`.
+
+## &lt;testbench&gt;.tbconf
+
+Simulation configuration for one test bench, stored next to it with the same base name:
+
+```json
+{
+  "simulator": "Verilator",
+  "TopModule": "top_tb",
+  "VerilatorArguments": "-Wno-fatal"
+}
+```
+
+`simulator` names the simulator; every other key is an option of that simulator. Read it with
+`fpga_get_testbench_config`, write it with `fpga_set_testbench_simulator` and
+`fpga_set_testbench_option`.
+
+A `.tbconf` is independent of the `testBenches` array in the project file: the array controls the
+test bench marker and toolbar in the IDE, the `.tbconf` controls how the file is simulated. In
+practice you want both.

--- a/src/OneWare.UniversalFpgaProjectSystem/Skills/fpga-studio-control/SKILL.md
+++ b/src/OneWare.UniversalFpgaProjectSystem/Skills/fpga-studio-control/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: fpga-studio-control
+description: How to drive ONE WARE Studio's FPGA project system from chat — which fpga_* function to call for creating a project, selecting board/toolchain/loader, setting the top entity, compiling, and running test benches, and in what order.
+---
+
+# Controlling the FPGA project system
+
+Every `fpga_*` function acts on the **active** FPGA project. There is exactly one active project
+at a time, and it is not necessarily the project whose file the user has open in the editor.
+
+## Orientation
+
+| Question | Function |
+| --- | --- |
+| Is an FPGA project active, and how is it configured? | `fpga_get_project_overview` |
+| Which projects are loaded? | `fpga_list_projects` |
+| What is installed (toolchains, loaders, simulators, boards, templates, pre-compile steps)? | `fpga_list_toolchains` |
+| Which files belong to the project, and how are they flagged? | `fpga_list_files` |
+
+Start every task with `fpga_get_project_overview`. If it reports that no project is active, either
+`fpga_set_active_project` an existing one, `fpga_open_project` a `.fpgaproj` from disk, or create a
+new one.
+
+`fpga_list_toolchains` is the only authoritative source of ids. A toolchain, loader, simulator or
+board that it does not list is not installed, and no other function will accept it. Never guess an
+id from the user's wording — map "iCE40 board" or "Yosys" onto a listed entry, and if nothing
+matches, say what is available.
+
+## Creating a project
+
+```
+fpga_list_toolchains            -> pick a toolchain id and a loader id
+fpga_create_project             -> name, optional directory, toolchain, loader, template
+fpga_set_board                  -> a board name from fpga_list_toolchains
+```
+
+`fpga_create_project` creates a folder, writes the `.fpgaproj`, loads the project and makes it
+active. It asks the user to confirm because it writes to disk. It does **not** select a board — a
+board is required before compiling, so always follow up with `fpga_set_board`.
+
+The optional template fills the project with starter sources. If the user wants to write the HDL
+themselves, omit it.
+
+## Configuring a project
+
+| Task | Function |
+| --- | --- |
+| Change the toolchain | `fpga_set_toolchain` |
+| Change the loader (programmer) | `fpga_set_loader` |
+| Change the board | `fpga_set_board` |
+| Set the top level entity/module | `fpga_set_top_entity` |
+| Change a registered project setting | `fpga_set_project_setting` |
+| Change a board device setting | `fpga_set_device_setting` |
+| Exclude a file from compilation | `fpga_set_compile_excluded` |
+| Mark a file as a test bench | `fpga_set_testbench` |
+
+All of these save the project file, so no separate save is needed. `fpga_save_project` exists only
+for the case where the project file was edited by other means.
+
+### Top entity
+
+`fpga_list_top_entities` parses the HDL sources and returns every entity/module that could be the
+top level, together with the file it lives in. Test benches and files excluded from compilation are
+skipped, which is exactly what you want — a test bench is never the top entity of a synthesis run.
+
+Only set a top entity that the list contains. If the list is empty, the language plugin for the
+sources is probably not installed; say so instead of setting a name that will fail at synthesis.
+
+### Project settings vs. device settings
+
+Two different stores, two different functions:
+
+- **Project settings** (`fpga_list_project_settings` / `fpga_set_project_setting`) are what the
+  project settings dialog shows. They live in the `.fpgaproj` file and are registered by plugins,
+  so which ones exist depends on the selected toolchain. Keys of the form `preCompileStep_<id>`
+  are booleans that enable or disable a pre-compile step.
+- **Device settings** (`fpga_list_device_settings` / `fpga_set_device_setting`) describe the
+  selected board and live in `device-settings/<board>.deviceconf`. They only exist once a board is
+  selected. Setting one to an empty value removes it, so the board default applies again.
+
+### Compile exclusions
+
+A file that is excluded from compilation stays in the project and stays visible, but is not passed
+to synthesis. Use it for alternative implementations of the same entity, for vendor sources that
+only the simulator needs, and for anything the user wants to keep but not build.
+
+Excluding a file is the correct answer to "the synthesizer complains about a file I don't need" —
+deleting it is not.
+
+## Compiling
+
+```
+fpga_get_project_overview       -> toolchain, board and top entity present?
+fpga_compile
+```
+
+`fpga_compile` saves the open files, runs the enabled pre-compile steps, and then the toolchain
+stages: synthesis, place & route, bitstream generation. **The build stops at the first stage that
+fails**, and a later stage never runs on a stale result from a previous build. That means the
+*first* error in the Output panel is the one to fix — later messages, if any, are consequences.
+
+The function itself returns only success or failure; the tool output goes to the Output panel. When
+it fails, ask the user for the relevant Output lines (or read the source that the error names)
+rather than re-running the same build.
+
+Compiling requires a confirmation because it runs external tools.
+
+## Simulating a test bench
+
+```
+fpga_set_testbench              -> path, true
+fpga_set_testbench_simulator    -> path, a simulator name from fpga_list_toolchains
+fpga_set_testbench_option       -> path, TopModule, <module name>      (usually needed)
+fpga_run_simulation             -> path
+```
+
+The per-test-bench configuration lives in a `.tbconf` file next to the test bench, not in the
+project file — `fpga_get_testbench_config` reads it back.
+
+Common options:
+
+| Key | Simulator | Meaning |
+| --- | --- | --- |
+| `TopModule` | all | Name of the module the simulator elaborates. Defaults to the file name. |
+| `VerilatorArguments` | Verilator | Extra compile-time arguments. |
+| `VerilatorRuntimeArguments` | Verilator | Arguments passed to the built simulation binary. |
+| `IcarusVerilogArguments` | Icarus Verilog | Extra arguments. |
+| `WaveOutputFormat` | Icarus Verilog | `VCD` or `FST`. |
+
+Verilator treats warnings as fatal by default, so a design that only produces warnings still fails
+the run. `-Wno-fatal` in `VerilatorArguments` downgrades them; `-Wno-<CODE>` silences one specific
+warning. Prefer fixing the source — a missing `` `timescale `` causing `TIMESCALEMOD` is a real
+inconsistency, not noise.
+
+## Rules
+
+- Read the error a function returns. It names the concrete problem and usually the function to call
+  next; retrying the identical call will fail identically.
+- Never invent ids, board names or entity names.
+- Ask before doing something the user did not ask for, especially before changing a board or a
+  toolchain — that invalidates pin assignments.

--- a/src/OneWare.UniversalFpgaProjectSystem/UniversalFpgaProjectSystemModule.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/UniversalFpgaProjectSystemModule.cs
@@ -4,12 +4,14 @@ using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.Input;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using OneWare.Essentials.Helpers;
 using OneWare.Essentials.Models;
 using OneWare.Essentials.Services;
 using OneWare.Essentials.ViewModels;
 using OneWare.UniversalFpgaProjectSystem.Models;
 using OneWare.UniversalFpgaProjectSystem.Services;
+using OneWare.UniversalFpgaProjectSystem.Services.Ai;
 using OneWare.UniversalFpgaProjectSystem.ViewModels;
 using OneWare.UniversalFpgaProjectSystem.Views;
 
@@ -129,6 +131,88 @@ public class UniversalFpgaProjectSystemModule : OneWareModuleBase
         fpgaService.RegisterProjectPropertyMigration("Fpga", "board"); // PascalCase variant also migrated
 
         RegisterProjectSettings(projectSettingsService, fpgaService);
+
+        RegisterFpgaAgent(serviceProvider, fpgaService, manager, projectSettingsService);
+    }
+
+    /// <summary>
+    /// Contributes the FPGA agent and its skills to the IDE chat, so the AI can create and configure
+    /// FPGA projects, pick a toolchain and board, compile and run test benches.
+    /// </summary>
+    /// <remarks>
+    /// The chat is an optional module — the browser studio ships without it — so the registration is
+    /// skipped when no function provider is registered. Resolving it unconditionally would build a
+    /// second, unused provider through the container fallback.
+    /// </remarks>
+    private static void RegisterFpgaAgent(IServiceProvider serviceProvider, FpgaService fpgaService,
+        UniversalFpgaProjectManager manager, IProjectSettingsService projectSettingsService)
+    {
+        if (!serviceProvider.IsRegistered<IAiFunctionProvider>()) return;
+
+        var logger = serviceProvider.Resolve<ILogger>();
+        var aiFunctionProvider = serviceProvider.Resolve<IAiFunctionProvider>();
+
+        // Skills ship next to the assembly, one sub-directory per skill, each with a SKILL.md.
+        var skillDirectory = FpgaSkillDirectoryLocator.TryResolve(typeof(UniversalFpgaProjectSystemModule).Assembly);
+
+        if (skillDirectory is null)
+            logger.Warning(
+                "FPGA agent skills were not found next to the assembly. The FPGA agent is registered without them.");
+        else
+            aiFunctionProvider.RegisterSkillDirectory(skillDirectory);
+
+        var functionNames = FpgaAiFunctionRegistrar.Register(aiFunctionProvider, fpgaService,
+            serviceProvider.Resolve<IProjectExplorerService>(), manager, projectSettingsService,
+            serviceProvider.Resolve<IPaths>());
+
+        logger.Log($"Registered {functionNames.Count} FPGA chat functions.");
+
+        aiFunctionProvider.RegisterAgent(new OneWareAiAgent
+        {
+            Name = "fpga",
+            DisplayName = "FPGA Agent",
+            Description = "Use for everything around FPGA projects in ONE WARE Studio: creating a new " +
+                          "project, selecting the board, toolchain and loader, setting the top entity, " +
+                          "changing project or device settings, excluding files from compilation, marking " +
+                          "and configuring test benches, compiling a design and running simulations.",
+            Instructions = """
+                           You help the user set up, change, compile and simulate FPGA projects in ONE
+                           WARE Studio.
+
+                           Always call fpga_get_project_overview first. It tells you whether an FPGA
+                           project is active and how it is configured. Then route:
+
+                           - No project yet: ask what board and language the user targets, call
+                             fpga_list_toolchains for the ids that are actually installed, then
+                             fpga_create_project followed by fpga_set_board.
+                           - A project exists: prefer the fpga_* functions over editing the .fpgaproj
+                             file by hand — see the fpga-project-file skill for the file format and
+                             the few fields that have no function.
+                           - Before compiling: a toolchain and a board must be selected and the top
+                             entity must match an entity that actually exists — verify with
+                             fpga_list_top_entities.
+                           - After a failed compile: read the Output panel error the function points
+                             at. The build stops at the first failing stage, so the first error is
+                             the relevant one; a later stage never runs on a stale result.
+                           - For a test bench: mark the file with fpga_set_testbench, select the
+                             simulator with fpga_set_testbench_simulator, set its options with
+                             fpga_set_testbench_option, then run fpga_run_simulation.
+
+                           Rules that always apply:
+                           - Never invent a toolchain, loader, board or simulator name. Take them
+                             from fpga_list_toolchains; what is not listed is not installed.
+                           - Ask instead of guessing when a choice changes the generated hardware.
+                             Keep questions short and offer a sensible default.
+                           - Compiling and programming drive real hardware and tools. State what a
+                             call does before you make it, and never start the same build twice
+                             because you did not wait for it to finish.
+                           - When a function reports an error, read it and act on it instead of
+                             retrying the same call unchanged. When it reports that no project is
+                             active, create one or ask the user to open one.
+                           - Explain what you are doing in the user's language.
+                           """,
+            Skills = ["fpga-studio-control", "fpga-project-file", "fpga-toolchain-yosys"]
+        });
     }
 
     private static void RegisterProjectSettings(IProjectSettingsService svc, FpgaService fpgaService)

--- a/src/OneWare.UniversalFpgaProjectSystem/UniversalFpgaProjectSystemModule.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/UniversalFpgaProjectSystemModule.cs
@@ -92,7 +92,7 @@ public class UniversalFpgaProjectSystemModule : OneWareModuleBase
 
         windowService.RegisterMenuItem("MainWindow_MainMenu/FPGA", new MenuItemModel("Download")
         {
-            Header = "Download",
+            Header = "Config FPGA",
             Command = new AsyncRelayCommand(() => toolBarViewModel.DownloadAsync()),
             Icon = new IconModel("VsImageLib.Download16X")
         }, new MenuItemModel("Compile")

--- a/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectPinPlannerViewModel.cs
+++ b/src/OneWare.UniversalFpgaProjectSystem/ViewModels/UniversalFpgaProjectPinPlannerViewModel.cs
@@ -38,7 +38,7 @@ public class UniversalFpgaProjectPinPlannerViewModel : FlexibleWindowViewModelBa
 
         this.WhenValueChanged(x => x.IsDirty).Subscribe(x =>
         {
-            Title = $"Pin Planner - {Project.Header}{(x ? "*" : "")}";
+            Title = $"Constraints - {Project.Header}{(x ? "*" : "")}";
         });
 
         _ = InitializeAsync();
@@ -261,7 +261,7 @@ public class UniversalFpgaProjectPinPlannerViewModel : FlexibleWindowViewModelBa
         }
         catch (Exception e)
         {
-            ContainerLocator.Container.Resolve<ILogger>().Error("Error initializing pin planner", e);
+            ContainerLocator.Container.Resolve<ILogger>().Error("Error initializing constraint editor", e);
         }
         finally
         {

--- a/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectPinPlannerView.axaml
+++ b/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectPinPlannerView.axaml
@@ -42,7 +42,7 @@
             <StackPanel Spacing="16">
                 <TextBlock Text="Configure Project" FontSize="18" FontWeight="Bold"
                            HorizontalAlignment="Center" />
-                <TextBlock Text="Please configure the required settings before opening the Pin Planner."
+                <TextBlock Text="Please configure the required settings before opening the Constraint Editor."
                            TextWrapping="Wrap" Opacity="0.7" HorizontalAlignment="Center" TextAlignment="Center" />
 
                 <ProgressBar IsIndeterminate="True" IsVisible="{Binding IsSetupLoading}"
@@ -67,7 +67,7 @@
                               IsEnabled="{Binding !IsSetupLoading}" />
                 </StackPanel>
 
-                <Button Classes="RoundButton PrimaryButton" Content="Load Pin Planner"
+                <Button Classes="RoundButton PrimaryButton" Content="Load Constraint Editor"
                         HorizontalAlignment="Center"
                         Command="{Binding ApplySetupAsync}"
                         IsEnabled="{Binding !IsSetupLoading}" />

--- a/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectToolBarView.axaml
+++ b/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectToolBarView.axaml
@@ -70,7 +70,7 @@
             <Image Source="{DynamicResource MaterialDesign.KeyboardArrowDown}" Width="10" Height="10" Margin="1 0" />
         </Button>
         <Separator Margin="0" Width="1" Background="{DynamicResource ThemeBorderLowBrush}" Height="24" />
-        <Button ToolTip.Tip="Programs FPGA" Command="{Binding DownloadAsync}"
+        <Button ToolTip.Tip="Configures the FPGA or writes the FLASH memory" Command="{Binding DownloadAsync}"
                 IsEnabled="{Binding Project.Loader, FallbackValue={x:Null}, Converter={x:Static ObjectConverters.IsNotNull}}">
             <StackPanel Margin="2 0 0 0" Orientation="Horizontal" Spacing="5">
                 <Grid VerticalAlignment="Center">
@@ -83,14 +83,14 @@
                         Source="{DynamicResource VsImageLib.DownloadAlternative16X}"
                         Height="14" Width="14" VerticalAlignment="Center" />
                 </Grid>
-                <TextBlock Text="Download" VerticalAlignment="Center" />
+                <TextBlock Text="Config FPGA" VerticalAlignment="Center" />
             </StackPanel>
         </Button>
         <Button>
             <Button.Flyout>
                 <Flyout FlyoutPresenterTheme="{StaticResource FlyoutNoPadding}">
                     <StackPanel Orientation="Vertical">
-                        <MenuItem Header="Long Term Programming"
+                        <MenuItem Header="Write FLASH Memory"
                                   Command="{Binding $parent[UserControl].((viewModels:UniversalFpgaProjectToolBarViewModel)DataContext).ToggleLongTermProgramming, FallbackValue={x:Null}}"
                                   CommandParameter="{Binding}">
                             <MenuItem.Icon>

--- a/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectToolBarView.axaml
+++ b/src/OneWare.UniversalFpgaProjectSystem/Views/UniversalFpgaProjectToolBarView.axaml
@@ -10,11 +10,11 @@
 
     <StackPanel Orientation="Horizontal">
         <Separator Margin="0" Width="1" Background="{DynamicResource ThemeBorderLowBrush}" Height="24" />
-        <Button ToolTip.Tip="Select signals and compile"
+        <Button ToolTip.Tip="Constraint Editor"
                 Command="{Binding OpenPinPlannerAsync}">
             <StackPanel Margin="2 0 0 0" Orientation="Horizontal" Spacing="5">
                 <Image Source="{DynamicResource CreateIcon}" Width="14" Height="14" VerticalAlignment="Center" />
-                <TextBlock Text="Pin Planner" VerticalAlignment="Center" />
+                <TextBlock Text="Constraints" VerticalAlignment="Center" />
             </StackPanel>
         </Button>
         <Button>


### PR DESCRIPTION
Addresses customer feedback on the FPGA toolchain, and adds an FPGA agent to the IDE chat.

## 1. UI labels

| Before | After |
| --- | --- |
| Run Fit | Run Place&Route |
| Run Assemble | Generate Bitstream |
| Long Term Programming | Write FLASH Memory |
| Download | Config FPGA |

Only the labels changed. Public API names (`FitAsync`, `AssembleAsync`, `IFpgaLoader.DownloadAsync`), setting keys and `MenuItemModel` ids are untouched, so existing `.fpgaproj`/`.deviceconf` files and third-party plugins keep working.

## 2. Compile now aborts when a tool fails

This was the serious one. `ChildProcessService.ExecuteShellAsync` never looked at the process exit code — success was derived purely from the output/error callbacks, and the nextpnr and pack handlers unconditionally `return true`, so those stages were literally unable to fail. Yosys prints `ERROR:` while the stdout handler matched `Error:` case-sensitively.

The result was exactly what the customer reported: Yosys errors were ignored, nextpnr happily consumed the **previous** run's `build/synth.json`, and the build "succeeded" on a stale netlist.

Fixed:

- `ChildProcessService` now reads `ExitCode` and fails on non-zero (guarded against the cancellation path). This applies to every caller, not just Yosys.
- Each stage deletes its own stale artifact before running and verifies the expected artifact exists afterwards.
- Each stage refuses to start when its input from the previous stage is missing.
- Error detection is case-insensitive.
- `OpenFpgaLoader` checks a bitstream exists before launching and reports the result.
- `FpgaService.RunToolchainAsync` was discarding `CompileAsync`'s return value and always returning `true` — same class of bug, now propagated.

A failed compile now names the stage that failed and stops there, so the first error is the real one.

## 3. Toolchain settings

The Compile settings dialog only exposed Yosys options. It is now *Toolchain Settings*, split into **Synthesis (Yosys)**, **Place & Route (nextpnr)** and **Bitstream (Pack)**, with a new **nextpnr Verbose** checkbox (`yosysToolchainNextPnrVerbose`) that adds `--verbose` and surfaces the full nextpnr output.

## 4. FPGA AI agent

A new `fpga` agent for the IDE chat, modeled on the ONE AI plugin's agent, so the Copilot integration can drive the FPGA project system.

23 functions in `src/OneWare.UniversalFpgaProjectSystem/Services/Ai/`:

| Group | Functions |
| --- | --- |
| Project | `list_projects`, `set_active_project`, `get_project_overview`, `create_project`, `open_project`, `save_project` |
| Toolchain | `list_toolchains`, `set_toolchain`, `set_loader`, `set_board`, `list_top_entities`, `set_top_entity`, `compile` |
| Settings | `list/set_project_setting` (incl. pre-compile steps), `list/set_device_setting` (`.deviceconf`) |
| Files | `list_files`, `set_compile_excluded`, `set_testbench` |
| Simulation | `get_testbench_config`, `set_testbench_simulator`, `set_testbench_option`, `run_simulation` (`.tbconf`) |

Plus three skills shipped as `Skills/<name>/SKILL.md`: `fpga-studio-control`, `fpga-project-file` and `fpga-toolchain-yosys` (registered by the OSS CAD module).

Notes:

- Registration is guarded by `IsRegistered<IAiFunctionProvider>()` — the browser studio ships without the chat module, and an unguarded `Resolve` would silently construct a second, useless provider.
- Errors are returned as `"Error: …"` text rather than thrown, so the model can correct a bad argument without a round trip through the user.
- `create_project`, `compile` and `run_simulation` require user confirmation.
- Value conversion mirrors `UniversalFpgaProjectSettingsEditorViewModel` so the agent and the settings dialog stay interchangeable writers.

## Testing

`dotnet build` clean; `dotnet test OneWare.slnx` → 111 passed, 0 failed.

A `code-review` pass over the agent caught and fixed: duplicate-project activation in `open_project`, unchecked saves and an orphaned folder in `create_project`, pre-compile steps always reported as disabled, unvalidated step ids, missing `ToUnixPath` normalization on path settings, a `KeyNotFoundException` on an unknown settings category, and an inverted `include` description in a skill.