### PR TITLE
Fix LSP Support + TypeScript Server + SemVer in package manager

### DIFF
--- a/build/props/Microsoft.Extensions.DependencyInjection.Abstractions.props
+++ b/build/props/Microsoft.Extensions.DependencyInjection.Abstractions.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9"/>
     </ItemGroup>
 </Project>

--- a/build/props/Microsoft.Extensions.DependencyInjection.props
+++ b/build/props/Microsoft.Extensions.DependencyInjection.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9"/>
     </ItemGroup>
 </Project>

--- a/build/props/Microsoft.Extensions.Logging.Abstractions.props
+++ b/build/props/Microsoft.Extensions.Logging.Abstractions.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9"/>
     </ItemGroup>
 </Project>

--- a/build/props/Microsoft.Extensions.Logging.props
+++ b/build/props/Microsoft.Extensions.Logging.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9"/>
     </ItemGroup>
 </Project>

--- a/build/props/OmniSharp.Extensions.Language.props
+++ b/build/props/OmniSharp.Extensions.Language.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <PackageReference Include="OneWare.OmniSharp.Extensions.LanguageClient" Version="1.0.0"/>
-        <PackageReference Include="OneWare.OmniSharp.Extensions.LanguageProtocol" Version="1.0.0"/>
+        <PackageReference Include="OneWare.OmniSharp.Extensions.LanguageClient" Version="1.0.1"/>
+        <PackageReference Include="OneWare.OmniSharp.Extensions.LanguageProtocol" Version="1.0.1"/>
     </ItemGroup>
 </Project>

--- a/build/props/OmniSharp.Extensions.Language.props
+++ b/build/props/OmniSharp.Extensions.Language.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.19.9"/>
-        <PackageReference Include="OmniSharp.Extensions.LanguageProtocol" Version="0.19.9"/>
+        <PackageReference Include="OneWare.OmniSharp.Extensions.LanguageClient" Version="1.0.0"/>
+        <PackageReference Include="OneWare.OmniSharp.Extensions.LanguageProtocol" Version="1.0.0"/>
     </ItemGroup>
 </Project>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 - Improve hover tooltips, they now show formatted documentation and the diagnostics separately
 - Improve completion tooltips, they now show the type of the symbol and mark deprecated entries
 - Highlight the parameter the cursor is on in the overload insight and start on the matching overload
+- Restyle rendered markdown after Visual Studio Code, everything from tooltips to release notes reads cleaner
 - Fix installed packages with prerelease versions showing as unavailable and not being removable
 - Fix completion crashing for language servers that return insert/replace text edits
 - Reduce language server log noise, servers now only report warnings and errors

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,9 @@
 
 - Add possibility to add custom AI Agents and Skills
 - Add TypeScript / Javascript Support
+- Improve hover tooltips, they now show formatted documentation and the diagnostics separately
+- Improve completion tooltips, they now show the type of the symbol and mark deprecated entries
+- Highlight the parameter the cursor is on in the overload insight and start on the matching overload
 - Fix installed packages with prerelease versions showing as unavailable and not being removable
 - Fix completion crashing for language servers that return insert/replace text edits
 - Reduce language server log noise, servers now only report warnings and errors

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 - Add possibility to add custom AI Agents and Skills
 - Add TypeScript / Javascript Support
+- Fix installed packages with prerelease versions showing as unavailable and not being removable
+- Fix completion crashing for language servers that return insert/replace text edits
+- Reduce language server log noise, servers now only report warnings and errors
+- Enable pull diagnostics for language servers that do not push diagnostics on their own
 
 ## 1.0.26
 
@@ -12,7 +16,7 @@
 
 ## 1.0.25
 
-- Add JavaScript/TypeScript language support (tsgo language server, auto-downloadable)
+- Add JavaScript/TypeScript language support (native tsc language server, auto-downloadable)
 - Support language servers that only provide pull diagnostics (textDocument/diagnostic)
 - Improve Copilot Terminal Handling in Windows
 - Add possibility to add default startup configuration

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 - Highlight the parameter the cursor is on in the overload insight and start on the matching overload
 - Restyle rendered markdown after Visual Studio Code, everything from tooltips to release notes reads cleaner
 - Fix the rename input box cutting off its text instead of growing with the editor font size
+- Fix hover and completion tips cutting off their content, they now scale with the editor font size
 - Fix installed packages with prerelease versions showing as unavailable and not being removable
 - Fix completion crashing for language servers that return insert/replace text edits
 - Reduce language server log noise, servers now only report warnings and errors

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 - Improve completion tooltips, they now show the type of the symbol and mark deprecated entries
 - Highlight the parameter the cursor is on in the overload insight and start on the matching overload
 - Restyle rendered markdown after Visual Studio Code, everything from tooltips to release notes reads cleaner
+- Fix the rename input box cutting off its text instead of growing with the editor font size
 - Fix installed packages with prerelease versions showing as unavailable and not being removable
 - Fix completion crashing for language servers that return insert/replace text edits
 - Reduce language server log noise, servers now only report warnings and errors

--- a/src/OneWare.Core/Styles/Editor.axaml
+++ b/src/OneWare.Core/Styles/Editor.axaml
@@ -7,7 +7,6 @@
         xmlns:folding="clr-namespace:AvaloniaEdit.Folding;assembly=AvaloniaEdit"
         xmlns:editorEx="clr-namespace:OneWare.Essentials.EditorExtensions;assembly=OneWare.Essentials"
         xmlns:snippets="clr-namespace:AvaloniaEdit.Snippets;assembly=AvaloniaEdit"
-        xmlns:colorTextBlock="clr-namespace:ColorTextBlock.Avalonia;assembly=ColorTextBlock.Avalonia"
         xmlns:controls="clr-namespace:OneWare.Essentials.Controls;assembly=OneWare.Essentials"
         xmlns:models="clr-namespace:OmniSharp.Extensions.LanguageServer.Protocol.Models;assembly=OmniSharp.Extensions.LanguageProtocol"
         xmlns:rendering="https://github.com/avaloniaui/avaloniaedit">
@@ -103,7 +102,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}" />
         <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
         <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
-        <Setter Property="Padding" Value="2" />
+        <Setter Property="Padding" Value="0" />
         <Setter Property="MaxHeight" Value="350" />
         <Setter Property="MaxWidth" Value="700" />
         <Setter Property="CornerRadius" Value="3" />
@@ -114,18 +113,7 @@
                             BorderThickness="1"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             Background="{TemplateBinding Background}">
-                        <controls:MarkdownViewer Markdown="{TemplateBinding Content}" Classes="ToolTip">
-                            <controls:MarkdownViewer.Styles>
-                                <Style Selector="avaloniaEdit|TextEditor">
-                                    <Setter Property="FontFamily" Value="{DynamicResource EditorFont}" />
-                                    <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
-                                </Style>
-                                <Style Selector="colorTextBlock|CTextBlock">
-                                    <Setter Property="FontFamily" Value="{DynamicResource EditorFont}" />
-                                    <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
-                                </Style>
-                            </controls:MarkdownViewer.Styles>
-                        </controls:MarkdownViewer>
+                        <controls:MarkdownViewer Markdown="{TemplateBinding Content}" Classes="ToolTip" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
@@ -190,48 +178,21 @@
                             </StackPanel>
                         </Border>
 
-                        <Border Grid.Row="0" Grid.Column="1" Padding="5">
+                        <Border Grid.Row="0" Grid.Column="1">
                             <controls:MarkdownViewer VerticalAlignment="Center"
                                                      HorizontalAlignment="Left"
-                                                     ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                                      SelectionEnabled="True"
-                                                     Classes="ToolTip"
-                                                     Markdown="{Binding Provider.CurrentHeader, RelativeSource={RelativeSource TemplatedParent}}">
-                                <controls:MarkdownViewer.Styles>
-                                    <Style Selector="avaloniaEdit|TextEditor">
-                                        <Setter Property="WordWrap" Value="True" />
-                                        <Setter Property="HorizontalScrollBarVisibility" Value="Disabled" />
-                                        <Setter Property="FontFamily" Value="{DynamicResource EditorFont}" />
-                                        <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
-                                    </Style>
-                                    <Style Selector="colorTextBlock|CTextBlock">
-                                        <Setter Property="FontFamily" Value="{DynamicResource EditorFont}" />
-                                        <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
-                                    </Style>
-                                </controls:MarkdownViewer.Styles>
-                            </controls:MarkdownViewer>
+                                                     Classes="ToolTip Signature"
+                                                     Markdown="{Binding Provider.CurrentHeader, RelativeSource={RelativeSource TemplatedParent}}" />
                         </Border>
 
                         <Border
                             IsVisible="{Binding Provider.CurrentContent, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNotNull}}"
-                            Grid.Row="1" Grid.Column="1" Padding="5" BorderThickness="0 1 0 0"
+                            Grid.Row="1" Grid.Column="1" BorderThickness="0 1 0 0"
                             BorderBrush="{DynamicResource ThemeBorderLowBrush}">
                             <controls:MarkdownViewer VerticalAlignment="Top" MaxHeight="250"
                                                      Classes="ToolTip"
-                                                     Markdown="{Binding Provider.CurrentContent, RelativeSource={RelativeSource TemplatedParent}}">
-                                <controls:MarkdownViewer.Styles>
-                                    <Style Selector="avaloniaEdit|TextEditor">
-                                        <Setter Property="WordWrap" Value="True" />
-                                        <Setter Property="HorizontalScrollBarVisibility" Value="Disabled" />
-                                        <Setter Property="FontFamily" Value="{DynamicResource EditorFont}" />
-                                        <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
-                                    </Style>
-                                    <Style Selector="colorTextBlock|CTextBlock">
-                                        <Setter Property="FontFamily" Value="{DynamicResource EditorFont}" />
-                                        <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
-                                    </Style>
-                                </controls:MarkdownViewer.Styles>
-                            </controls:MarkdownViewer>
+                                                     Markdown="{Binding Provider.CurrentContent, RelativeSource={RelativeSource TemplatedParent}}" />
                         </Border>
                     </Grid>
                 </Border>

--- a/src/OneWare.Core/Styles/Editor.axaml
+++ b/src/OneWare.Core/Styles/Editor.axaml
@@ -206,7 +206,11 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <TextBox Name="inputBox" IsReadOnly="False" />
+                    <!-- Height is auto so the box follows the editor font size instead of the fixed height every TextBox gets -->
+                    <TextBox Name="inputBox" IsReadOnly="False" Height="NaN"
+                             MinWidth="100" MaxWidth="500"
+                             VerticalContentAlignment="Center"
+                             ScrollViewer.VerticalScrollBarVisibility="Disabled" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/src/OneWare.Core/Styles/Editor.axaml
+++ b/src/OneWare.Core/Styles/Editor.axaml
@@ -56,9 +56,14 @@
                                                    Height="{Binding #CompletionName.Bounds.Height}" />
                                             <TextBlock VerticalAlignment="Center" Padding="0" Name="CompletionName"
                                                        Margin="8,0,0,0" Text="{Binding Label}"
+                                                       Classes.Deprecated="{Binding IsDeprecated}"
                                                        Foreground="{DynamicResource ThemeForegroundBrush}" />
+                                            <TextBlock VerticalAlignment="Center" Padding="0"
+                                                       Text="{Binding LabelDetail}"
+                                                       TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
+                                                       Foreground="{DynamicResource ThemeForegroundLowBrush}" />
                                         </StackPanel>
-                                        <TextBlock Grid.Column="2" Text="{Binding Detail}"
+                                        <TextBlock Grid.Column="2" Text="{Binding Annotation}"
                                                    Foreground="{DynamicResource ThemeForegroundLowBrush}"
                                                    TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
                                                    TextAlignment="Right" HorizontalAlignment="Right" />
@@ -84,6 +89,10 @@
         <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
     </Style>
 
+    <Style Selector="cc|CompletionList TextBlock.Deprecated">
+        <Setter Property="TextDecorations" Value="Strikethrough" />
+    </Style>
+
     <Style Selector="cc|CompletionList > ListBox > ListBoxItem">
         <Setter Property="Margin" Value="0" />
         <Setter Property="Padding" Value="5, 3, 3, 3" />
@@ -105,7 +114,7 @@
                             BorderThickness="1"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             Background="{TemplateBinding Background}">
-                        <controls:MarkdownViewer Markdown="{TemplateBinding Content}">
+                        <controls:MarkdownViewer Markdown="{TemplateBinding Content}" Classes="ToolTip">
                             <controls:MarkdownViewer.Styles>
                                 <Style Selector="avaloniaEdit|TextEditor">
                                     <Setter Property="FontFamily" Value="{DynamicResource EditorFont}" />
@@ -208,6 +217,7 @@
                             Grid.Row="1" Grid.Column="1" Padding="5" BorderThickness="0 1 0 0"
                             BorderBrush="{DynamicResource ThemeBorderLowBrush}">
                             <controls:MarkdownViewer VerticalAlignment="Top" MaxHeight="250"
+                                                     Classes="ToolTip"
                                                      Markdown="{Binding Provider.CurrentContent, RelativeSource={RelativeSource TemplatedParent}}">
                                 <controls:MarkdownViewer.Styles>
                                     <Style Selector="avaloniaEdit|TextEditor">

--- a/src/OneWare.Core/Styles/Editor.axaml
+++ b/src/OneWare.Core/Styles/Editor.axaml
@@ -103,8 +103,6 @@
         <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
         <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
         <Setter Property="Padding" Value="0" />
-        <Setter Property="MaxHeight" Value="350" />
-        <Setter Property="MaxWidth" Value="700" />
         <Setter Property="CornerRadius" Value="3" />
         <Setter Property="Template">
             <Setter.Value>
@@ -145,8 +143,6 @@
                 Value="{DynamicResource ThemeBackgroundBrush}" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="CornerRadius" Value="3" />
-        <Setter Property="MaxWidth" Value="800" />
-        <Setter Property="MaxHeight" Value="400" />
         <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
         <Setter Property="Template">
             <ControlTemplate>
@@ -190,7 +186,7 @@
                             IsVisible="{Binding Provider.CurrentContent, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNotNull}}"
                             Grid.Row="1" Grid.Column="1" BorderThickness="0 1 0 0"
                             BorderBrush="{DynamicResource ThemeBorderLowBrush}">
-                            <controls:MarkdownViewer VerticalAlignment="Top" MaxHeight="250"
+                            <controls:MarkdownViewer VerticalAlignment="Top"
                                                      Classes="ToolTip"
                                                      Markdown="{Binding Provider.CurrentContent, RelativeSource={RelativeSource TemplatedParent}}" />
                         </Border>

--- a/src/OneWare.Core/Styles/MarkdownViewer.axaml
+++ b/src/OneWare.Core/Styles/MarkdownViewer.axaml
@@ -112,7 +112,8 @@
                         </Style>
 
                         <Style Selector=".ToolTip mdxaml|MarkdownScrollViewer ScrollViewer">
-                            <Setter Property="VerticalScrollBarVisibility" Value="Disabled" />
+                            <!-- Documentation can be longer than the tip, cutting it off silently helps nobody -->
+                            <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
                         </Style>
 
                         <Style Selector=".ToolTip Border.CodeBlock avaloniaEdit|TextEditor">

--- a/src/OneWare.Core/Styles/MarkdownViewer.axaml
+++ b/src/OneWare.Core/Styles/MarkdownViewer.axaml
@@ -1,7 +1,8 @@
-﻿<Styles xmlns="https://github.com/avaloniaui"
+<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:OneWare.Essentials.Controls;assembly=OneWare.Essentials"
         xmlns:mdxaml="https://github.com/whistyun/Markdown.Avalonia.Tight"
+        xmlns:mdc="clr-namespace:Markdown.Avalonia.Controls;assembly=Markdown.Avalonia"
         xmlns:ctxt="clr-namespace:ColorTextBlock.Avalonia;assembly=ColorTextBlock.Avalonia"
         xmlns:extensions="clr-namespace:Markdown.Avalonia.Extensions;assembly=Markdown.Avalonia"
         xmlns:avaloniaEdit="https://github.com/avaloniaui/avaloniaedit">
@@ -26,46 +27,93 @@
                     </mdxaml:MarkdownScrollViewer.Plugins>
                     <mdxaml:MarkdownScrollViewer.Styles>
 
-                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CCode">
-                            <Style.Setters>
-                                <Setter Property="Foreground"
-                                        Value="{extensions:DivideColor HighlightBrush, ThemeForegroundColor, 0.45}" />
-                                <Setter Property="Background" Value="{extensions:Alpha ThemeControlMidColor, 0.9}" />
-                            </Style.Setters>
+                        <!-- ============ Text ============ -->
+
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CTextBlock">
+                            <Setter Property="Margin" Value="0" />
+                            <Setter Property="TextWrapping" Value="Wrap" />
                         </Style>
+
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CTextBlock.Paragraph">
+                            <Setter Property="Margin" Value="0,0,0,8" />
+                        </Style>
+
+                        <!-- ============ Headings ============ -->
+
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CTextBlock.Heading1">
+                            <Setter Property="FontSize" Value="{extensions:Multiply FontSizeNormal, 1.6}" />
+                            <Setter Property="FontWeight" Value="SemiBold" />
+                            <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
+                            <Setter Property="Margin" Value="0,12,0,6" />
+                        </Style>
+
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CTextBlock.Heading2">
+                            <Setter Property="FontSize" Value="{extensions:Multiply FontSizeNormal, 1.35}" />
+                            <Setter Property="FontWeight" Value="SemiBold" />
+                            <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
+                            <Setter Property="Margin" Value="0,12,0,6" />
+                        </Style>
+
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CTextBlock.Heading3">
+                            <Setter Property="FontSize" Value="{extensions:Multiply FontSizeNormal, 1.15}" />
+                            <Setter Property="FontWeight" Value="SemiBold" />
+                            <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
+                            <Setter Property="Margin" Value="0,10,0,4" />
+                        </Style>
+
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CTextBlock.Heading4">
+                            <Setter Property="FontSize" Value="{extensions:Multiply FontSizeNormal, 1.0}" />
+                            <Setter Property="FontWeight" Value="Bold" />
+                            <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
+                            <Setter Property="Margin" Value="0,10,0,4" />
+                        </Style>
+
+                        <!-- ============ Links ============ -->
 
                         <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CHyperlink">
-                            <Style.Setters>
-                                <Setter Property="IsUnderline" Value="False" />
-                                <Setter Property="Foreground" Value="{DynamicResource HighlightBrush}" />
-                            </Style.Setters>
+                            <Setter Property="IsUnderline" Value="False" />
+                            <Setter Property="Foreground" Value="{DynamicResource HighlightBrush}" />
                         </Style>
 
-                        <Style Selector="ScrollViewer">
-                            <Setter Property="Padding" Value="5" />
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CHyperlink:pointerover">
+                            <Setter Property="IsUnderline" Value="True" />
+                            <Setter Property="Foreground" Value="{DynamicResource HighlightBrush}" />
                         </Style>
 
-                        <Style Selector="Grid.List">
-                            <Setter Property="Margin" Value="20 0 0 0" />
+                        <!-- ============ Code ============ -->
+
+                        <!-- Tinting the foreground colour keeps code readable in both light and dark themes -->
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CCode">
+                            <Setter Property="FontFamily" Value="{DynamicResource EditorFont}" />
+                            <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
+                            <Setter Property="Background" Value="{extensions:Alpha ThemeForegroundColor, 0.12}" />
                         </Style>
 
-                        <Style Selector="ctxt|CTextBlock.Heading1">
-                            <Setter Property="FontSize" Value="{extensions:Multiply FontSizeNormal, 2.0}" />
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer Border.CodeBlock">
+                            <Setter Property="Background" Value="{extensions:Alpha ThemeForegroundColor, 0.06}" />
+                            <Setter Property="BorderThickness" Value="0" />
+                            <Setter Property="CornerRadius" Value="4" />
+                            <Setter Property="Padding" Value="10,8" />
+                            <Setter Property="Margin" Value="0,2,0,8" />
                         </Style>
 
-                        <Style Selector="ctxt|CTextBlock.Heading2">
-                            <Setter Property="FontSize" Value="{extensions:Multiply FontSizeNormal, 1.6}" />
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer Border.CodeBlock avaloniaEdit|TextEditor">
+                            <Setter Property="FontFamily" Value="{DynamicResource EditorFont}" />
+                            <Setter Property="Background" Value="Transparent" />
+                            <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="False" />
                         </Style>
 
-                        <Style Selector="ctxt|CTextBlock.Heading3">
-                            <Setter Property="FontSize" Value="{extensions:Multiply FontSizeNormal, 1.3}" />
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer TextBlock.CodeBlock">
+                            <Setter Property="FontFamily" Value="{DynamicResource EditorFont}" />
+                            <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
+                            <Setter Property="MinHeight" Value="20" />
                         </Style>
 
-                        <Style Selector="Border.CodeBlock Label.LangInfo">
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer Border.CodeBlock Label.LangInfo">
                             <Setter Property="IsVisible" Value="False" />
                         </Style>
 
-                        <Style Selector="Border.CodeBlock Button.CopyButton ContentPresenter">
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer Border.CodeBlock Button.CopyButton ContentPresenter">
                             <Setter Property="CornerRadius" Value="3" />
                             <Setter Property="Cursor" Value="Hand" />
                             <Setter Property="Content">
@@ -76,84 +124,133 @@
                             </Setter>
                         </Style>
 
-                        <Style Selector="Border.CodeBlock">
-                            <Style.Setters>
-                                <Setter Property="Margin" Value="0" />
-                                <Setter Property="Padding" Value="5" />
-                                <Setter Property="CornerRadius" Value="3" />
-                                <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}" />
-                                <Setter Property="BorderThickness" Value="1" />
-                            </Style.Setters>
+                        <!-- ============ Rules, quotes and lists ============ -->
+
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer mdc|Rule">
+                            <Setter Property="Foreground" Value="{DynamicResource ThemeBorderLowBrush}" />
+                            <Setter Property="SingleLineWidth" Value="1" />
+                            <Setter Property="BoldLineWidth" Value="2" />
+                            <Setter Property="LineMargin" Value="0" />
+                            <Setter Property="Margin" Value="0,6" />
                         </Style>
 
-                        <Style Selector="Border.CodeBlock avaloniaEdit|TextEditor">
-                            <Setter Property="FontFamily" Value="{DynamicResource EditorFont}" />
-                            <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="False" />
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer Border.Blockquote">
+                            <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}" />
+                            <Setter Property="BorderThickness" Value="3,0,0,0" />
                         </Style>
 
-                        <Style Selector="ctxt|CCode">
-                            <Style.Setters>
-                                <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
-                                <Setter Property="Background" Value="{DynamicResource ThemeBorderLowBrush}" />
-                            </Style.Setters>
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer StackPanel.Blockquote">
+                            <Setter Property="Margin" Value="10,2,0,2" />
                         </Style>
-                        
-                        <Style Selector="TextBlock.CodeBlock">
-                            <Style.Setters>
-                                <Setter Property="FontFamily" Value="menlo,monaco,consolas,droid sans mono,inconsolata,courier new,monospace,dejavu sans mono"/>
-                                <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
-                                <Setter Property="MinHeight" Value="20" />
-                            </Style.Setters>
+
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer Grid.List">
+                            <Setter Property="Margin" Value="16,0,0,0" />
                         </Style>
+
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ctxt|CTextBlock.ListMarker">
+                            <Setter Property="Margin" Value="0,0,6,0" />
+                        </Style>
+
+                        <!-- ============ Tables ============ -->
+
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer Border.Table">
+                            <Setter Property="Margin" Value="0,2,0,8" />
+                            <Setter Property="BorderThickness" Value="0,0,1,1" />
+                            <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}" />
+                        </Style>
+
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer Grid.Table > Border">
+                            <Setter Property="Margin" Value="0" />
+                            <Setter Property="Padding" Value="8,4" />
+                            <Setter Property="BorderThickness" Value="1,1,0,0" />
+                            <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}" />
+                        </Style>
+
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer Border.TableHeader">
+                            <Setter Property="Background" Value="{extensions:Alpha ThemeForegroundColor, 0.06}" />
+                        </Style>
+
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer Border.TableHeader ctxt|CTextBlock">
+                            <Setter Property="FontWeight" Value="SemiBold" />
+                        </Style>
+
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer Border.EvenTableRow">
+                            <Setter Property="Background" Value="{extensions:Alpha ThemeForegroundColor, 0.03}" />
+                        </Style>
+
+                        <Style Selector="ScrollViewer">
+                            <Setter Property="Padding" Value="5" />
+                        </Style>
+
+                        <!-- ============ Tooltips ============ -->
+                        <!-- Hover, completion and overload tips, everything tighter and without chrome -->
 
                         <Style Selector=".ToolTip mdxaml|MarkdownScrollViewer">
-                            <Setter Property="MaxWidth" Value="500" />
-                            <Setter Property="MaxHeight" Value="300" />
+                            <Setter Property="MaxWidth" Value="520" />
+                            <Setter Property="MaxHeight" Value="320" />
                         </Style>
 
-                        <Style Selector=".ToolTip mdxaml|MarkdownScrollViewer ScrollViewer">
+                        <Style Selector=".ToolTip ScrollViewer">
+                            <Setter Property="Padding" Value="8,6" />
                             <!-- Documentation can be longer than the tip, cutting it off silently helps nobody -->
                             <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
+                            <Setter Property="HorizontalScrollBarVisibility" Value="Disabled" />
+                        </Style>
+
+                        <Style Selector=".ToolTip TextBlock">
+                            <Setter Property="MaxWidth" Value="496" />
+                        </Style>
+
+                        <Style Selector=".ToolTip ctxt|CTextBlock">
+                            <Setter Property="MaxWidth" Value="496" />
+                            <Setter Property="Margin" Value="0" />
+                        </Style>
+
+                        <Style Selector=".ToolTip ctxt|CTextBlock.Paragraph">
+                            <Setter Property="Margin" Value="0,0,0,4" />
+                        </Style>
+
+                        <Style Selector=".ToolTip ctxt|CTextBlock.Heading1, .ToolTip ctxt|CTextBlock.Heading2, .ToolTip ctxt|CTextBlock.Heading3, .ToolTip ctxt|CTextBlock.Heading4">
+                            <Setter Property="FontSize" Value="{extensions:Multiply FontSizeNormal, 1.1}" />
+                            <Setter Property="FontWeight" Value="SemiBold" />
+                            <Setter Property="Margin" Value="0,4,0,2" />
+                        </Style>
+
+                        <Style Selector=".ToolTip ctxt|CTextBlock.ListMarker">
+                            <Setter Property="Margin" Value="0,0,5,0" />
+                        </Style>
+
+                        <Style Selector=".ToolTip Grid.List">
+                            <Setter Property="Margin" Value="12,0,0,0" />
+                        </Style>
+
+                        <!-- Code sits on the tip background instead of in a box of its own -->
+                        <Style Selector=".ToolTip Border.CodeBlock">
+                            <Setter Property="Background" Value="Transparent" />
+                            <Setter Property="BorderThickness" Value="0" />
+                            <Setter Property="CornerRadius" Value="0" />
+                            <Setter Property="Padding" Value="0" />
+                            <Setter Property="Margin" Value="0,0,0,4" />
                         </Style>
 
                         <Style Selector=".ToolTip Border.CodeBlock avaloniaEdit|TextEditor">
                             <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
-                        </Style>
-
-                        <Style Selector=".ToolTip TextBlock">
-                            <Style.Setters>
-                                <Setter Property="MaxWidth" Value="490" />
-                            </Style.Setters>
-                        </Style>
-
-                        <Style Selector=".ToolTip ctxt|CTextBlock">
-                            <Style.Setters>
-                                <Setter Property="MaxWidth" Value="490" />
-                                <Setter Property="Margin" Value="0" />
-                            </Style.Setters>
-                        </Style>
-
-                        <Style Selector=".ToolTip ctxt|CTextBlock.Paragraph">
-                            <Style.Setters>
-                                <Setter Property="MaxWidth" Value="490" />
-                                <Setter Property="Margin" Value="0" />
-                            </Style.Setters>
-                        </Style>
-                        
-                        <Style Selector=".ToolTip ctxt|CTextBlock.ListMarker">
-                            <Style.Setters>
-                                <Setter Property="Margin" Value="0,0,5, 0"/>
-                            </Style.Setters>
+                            <Setter Property="WordWrap" Value="True" />
+                            <Setter Property="HorizontalScrollBarVisibility" Value="Disabled" />
                         </Style>
 
                         <Style Selector=".ToolTip Border.CodeBlock Button.CopyButton ContentPresenter">
                             <Setter Property="IsVisible" Value="False" />
                         </Style>
-                        
-                        <Style Selector=".ToolTip Border.CodeBlock">
-                            <Setter Property="Background" Value="Transparent" />
-                            <Setter Property="BorderThickness" Value="0" />
-                            <Setter Property="Padding" Value="2" />
+
+                        <Style Selector=".ToolTip mdc|Rule">
+                            <Setter Property="Margin" Value="0,2,0,6" />
+                        </Style>
+
+                        <!-- The overload insight shows a signature, so it reads better in the editor font -->
+                        <Style Selector=".Signature ctxt|CTextBlock">
+                            <Setter Property="FontFamily" Value="{DynamicResource EditorFont}" />
+                            <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
                         </Style>
 
                     </mdxaml:MarkdownScrollViewer.Styles>

--- a/src/OneWare.Core/Styles/MarkdownViewer.axaml
+++ b/src/OneWare.Core/Styles/MarkdownViewer.axaml
@@ -198,10 +198,13 @@
                         </Style>
 
                         <Style Selector=".ToolTip TextBlock">
+                            <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
                             <Setter Property="MaxWidth" Value="496" />
                         </Style>
 
+                        <!-- Tips sit next to the editor and quote code, so they follow the editor font size -->
                         <Style Selector=".ToolTip ctxt|CTextBlock">
+                            <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
                             <Setter Property="MaxWidth" Value="496" />
                             <Setter Property="Margin" Value="0" />
                         </Style>
@@ -211,7 +214,7 @@
                         </Style>
 
                         <Style Selector=".ToolTip ctxt|CTextBlock.Heading1, .ToolTip ctxt|CTextBlock.Heading2, .ToolTip ctxt|CTextBlock.Heading3, .ToolTip ctxt|CTextBlock.Heading4">
-                            <Setter Property="FontSize" Value="{extensions:Multiply FontSizeNormal, 1.1}" />
+                            <Setter Property="FontSize" Value="{extensions:Multiply EditorFontSize, 1.15}" />
                             <Setter Property="FontWeight" Value="SemiBold" />
                             <Setter Property="Margin" Value="0,4,0,2" />
                         </Style>

--- a/src/OneWare.Core/Styles/MarkdownViewer.axaml
+++ b/src/OneWare.Core/Styles/MarkdownViewer.axaml
@@ -244,14 +244,13 @@
                             <Setter Property="BorderThickness" Value="0" />
                             <Setter Property="CornerRadius" Value="0" />
                             <Setter Property="Padding" Value="0" />
-                            <Setter Property="Margin" Value="0,0,0,4" />
+                            <Setter Property="Margin" Value="0,0,0,0" />
                         </Style>
 
                         <Style Selector=".ToolTip Border.CodeBlock avaloniaEdit|TextEditor">
                             <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
                             <Setter Property="WordWrap" Value="True" />
                             <Setter Property="HorizontalScrollBarVisibility" Value="Disabled" />
-                            <Setter Property="IsVisible" Value="False"></Setter>
                         </Style>
 
                         <Style Selector=".ToolTip Border.CodeBlock Button.CopyButton ContentPresenter">

--- a/src/OneWare.Core/Styles/MarkdownViewer.axaml
+++ b/src/OneWare.Core/Styles/MarkdownViewer.axaml
@@ -185,9 +185,11 @@
                         <!-- ============ Tooltips ============ -->
                         <!-- Hover, completion and overload tips, everything tighter and without chrome -->
 
+                        <!-- Sized in editor lines rather than pixels, so a tip shows the same amount
+                             of text whatever the editor font size is set to -->
                         <Style Selector=".ToolTip mdxaml|MarkdownScrollViewer">
-                            <Setter Property="MaxWidth" Value="520" />
-                            <Setter Property="MaxHeight" Value="320" />
+                            <Setter Property="MaxWidth" Value="{extensions:Multiply EditorFontSize, 34}" />
+                            <Setter Property="MaxHeight" Value="{extensions:Multiply EditorFontSize, 21}" />
                         </Style>
 
                         <Style Selector=".ToolTip ScrollViewer">
@@ -199,13 +201,13 @@
 
                         <Style Selector=".ToolTip TextBlock">
                             <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
-                            <Setter Property="MaxWidth" Value="496" />
+                            <Setter Property="MaxWidth" Value="{extensions:Multiply EditorFontSize, 31}" />
                         </Style>
 
                         <!-- Tips sit next to the editor and quote code, so they follow the editor font size -->
                         <Style Selector=".ToolTip ctxt|CTextBlock">
                             <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
-                            <Setter Property="MaxWidth" Value="496" />
+                            <Setter Property="MaxWidth" Value="{extensions:Multiply EditorFontSize, 31}" />
                             <Setter Property="Margin" Value="0" />
                         </Style>
 

--- a/src/OneWare.Core/Styles/MarkdownViewer.axaml
+++ b/src/OneWare.Core/Styles/MarkdownViewer.axaml
@@ -106,7 +106,15 @@
                         <Style Selector=".Markdown_Avalonia_MarkdownViewer TextBlock.CodeBlock">
                             <Setter Property="FontFamily" Value="{DynamicResource EditorFont}" />
                             <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
-                            <Setter Property="MinHeight" Value="20" />
+                        </Style>
+
+                        <!--
+                            Padding on this scroll viewer is subtracted from the height its content gets arranged
+                            at, so a code block loses those pixels off the bottom once the editor font grows past
+                            the padding. Border.CodeBlock supplies the inset instead.
+                        -->
+                        <Style Selector=".Markdown_Avalonia_MarkdownViewer ScrollViewer.CodeBlock">
+                            <Setter Property="Padding" Value="0" />
                         </Style>
 
                         <Style Selector=".Markdown_Avalonia_MarkdownViewer Border.CodeBlock Label.LangInfo">
@@ -192,7 +200,8 @@
                             <Setter Property="MaxHeight" Value="{extensions:Multiply EditorFontSize, 21}" />
                         </Style>
 
-                        <Style Selector=".ToolTip ScrollViewer">
+                        <!-- Only the tip's own scroll viewer, never the one a code block nests inside -->
+                        <Style Selector=".ToolTip ScrollViewer:not(.CodeBlock)">
                             <Setter Property="Padding" Value="8,6" />
                             <!-- Documentation can be longer than the tip, cutting it off silently helps nobody -->
                             <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
@@ -242,6 +251,7 @@
                             <Setter Property="FontSize" Value="{DynamicResource EditorFontSize}" />
                             <Setter Property="WordWrap" Value="True" />
                             <Setter Property="HorizontalScrollBarVisibility" Value="Disabled" />
+                            <Setter Property="IsVisible" Value="False"></Setter>
                         </Style>
 
                         <Style Selector=".ToolTip Border.CodeBlock Button.CopyButton ContentPresenter">

--- a/src/OneWare.Core/Views/DockViews/EditView.axaml
+++ b/src/OneWare.Core/Views/DockViews/EditView.axaml
@@ -92,7 +92,7 @@
                 </ContentControl.Styles>
             </ContentControl>
 
-            <Popup Name="HoverBox" IsLightDismissEnabled="False" MaxWidth="700">
+            <Popup Name="HoverBox" IsLightDismissEnabled="False">
                 <Grid>
                     <ContentControl Name="HoverBoxContent" Padding="2" CornerRadius="3" BorderThickness="1"
                                     BorderBrush="{DynamicResource ThemeBorderLowBrush}"

--- a/src/OneWare.Essentials/EditorExtensions/CompletionData.cs
+++ b/src/OneWare.Essentials/EditorExtensions/CompletionData.cs
@@ -67,6 +67,23 @@ public partial class CompletionData : ICompletionData
 
     public string? SortText { get; set; }
 
+    /// <summary>
+    ///     Extra label text a server may send, shown right behind the label. Usually the parameter list.
+    /// </summary>
+    public string? LabelDetail { get; set; }
+
+    /// <summary>
+    ///     Where the symbol comes from, for example the module it is imported from.
+    /// </summary>
+    public string? LabelDescription { get; set; }
+
+    public bool IsDeprecated { get; set; }
+
+    /// <summary>
+    ///     The dimmed text on the right of a completion entry.
+    /// </summary>
+    public string? Annotation => LabelDescription ?? Detail;
+
     public string Text => FilterText ?? Label;
 
     public bool IsSnippet { get; set; } = true;

--- a/src/OneWare.Essentials/EditorExtensions/TextInputWindow.cs
+++ b/src/OneWare.Essentials/EditorExtensions/TextInputWindow.cs
@@ -35,7 +35,7 @@ public class TextInputWindow : Popup
 
         PlacementGravity = PopupGravity.BottomRight;
         PlacementAnchor = PopupAnchor.TopLeft;
-
+        
         Closed += (sender, args) => DetachEvents();
 
         AttachEvents();

--- a/src/OneWare.Essentials/Extensions/StringOrMarkupContentExtensions.cs
+++ b/src/OneWare.Essentials/Extensions/StringOrMarkupContentExtensions.cs
@@ -1,0 +1,18 @@
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace OneWare.Essentials.Extensions;
+
+public static class StringOrMarkupContentExtensions
+{
+    /// <summary>
+    ///     Reads the text of a value that a language server may send either as a plain string or as
+    ///     markup, for places that can only display plain text.
+    /// </summary>
+    public static string? GetPlainText(this StringOrMarkupContent? content)
+    {
+        if (content == null) return null;
+        if (content.HasString) return content.String;
+        if (content.HasMarkupContent) return content.MarkupContent?.Value;
+        return null;
+    }
+}

--- a/src/OneWare.Essentials/Extensions/StringOrMarkupContentExtensions.cs
+++ b/src/OneWare.Essentials/Extensions/StringOrMarkupContentExtensions.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace OneWare.Essentials.Extensions;
@@ -14,5 +15,48 @@ public static class StringOrMarkupContentExtensions
         if (content.HasString) return content.String;
         if (content.HasMarkupContent) return content.MarkupContent?.Value;
         return null;
+    }
+
+    /// <summary>
+    ///     Reads the text of a value that a language server may send either as a plain string or as
+    ///     markup and returns it as markdown, ready to be shown in a markdown viewer.
+    /// </summary>
+    public static string? GetMarkdown(this StringOrMarkupContent? content)
+    {
+        if (content == null) return null;
+
+        var markdown = content switch
+        {
+            { HasMarkupContent: true, MarkupContent: { } markup } => markup.Kind == MarkupKind.Markdown
+                ? markup.Value.Trim()
+                : EscapeMarkdown(markup.Value).Trim(),
+            { HasString: true } => EscapeMarkdown(content.String).Trim(),
+            _ => null
+        };
+
+        return string.IsNullOrWhiteSpace(markdown) ? null : markdown;
+    }
+
+    /// <summary>
+    ///     Turns plain text into markdown that renders verbatim. Line breaks are kept and the
+    ///     characters that would otherwise be read as emphasis are escaped. Surrounding whitespace is
+    ///     left alone so that fragments of a larger text can be escaped one by one.
+    /// </summary>
+    public static string EscapeMarkdown(string? plainText)
+    {
+        if (string.IsNullOrEmpty(plainText)) return string.Empty;
+
+        var builder = new StringBuilder(plainText.Length + 16);
+
+        foreach (var character in plainText.ReplaceLineEndings("\n"))
+        {
+            //Escaping anything else would leave the backslash visible, the renderer only knows these
+            if (character is '\\' or '*' or '_' or '~') builder.Append('\\');
+            //Two trailing spaces make the renderer keep the line break instead of joining the lines
+            if (character is '\n') builder.Append("  ");
+            builder.Append(character);
+        }
+
+        return builder.ToString();
     }
 }

--- a/src/OneWare.Essentials/LanguageService/LanguageServiceBase.cs
+++ b/src/OneWare.Essentials/LanguageService/LanguageServiceBase.cs
@@ -327,7 +327,8 @@ public abstract class LanguageServiceBase : ILanguageService
             if (p.Range.Start.Line == endLine && p.Range.Start.Character == endCharacter)
                 endCharacter++;
 
-            yield return new ErrorListItem(p.Message, errorType, fullPath, Name, p.Range.Start.Line + 1,
+            yield return new ErrorListItem(p.Message.GetPlainText() ?? string.Empty, errorType, fullPath, Name,
+                p.Range.Start.Line + 1,
                 p.Range.Start.Character + 1, endLine + 1, endCharacter + 1,
                 p.Code?.String ?? p.Code?.Long.ToString() ?? "", p, root);
         }

--- a/src/OneWare.Essentials/LanguageService/LanguageServiceLsp.cs
+++ b/src/OneWare.Essentials/LanguageService/LanguageServiceLsp.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Net.WebSockets;
 using System.Runtime.InteropServices;
 using Asmichi.ProcessManagement;
@@ -389,9 +390,19 @@ public abstract class LanguageServiceLsp(string name, string? workspace) : Langu
     {
     }
 
+    /// <summary>
+    ///     window/logMessage is the server's own diagnostic log, not something the user asked for.
+    ///     Servers log every handled request there, so only problems are kept at a visible level.
+    /// </summary>
     private void WriteLog(LogMessageParams log)
     {
-        var level = MapMessageType(log.Type);
+        var level = log.Type switch
+        {
+            MessageType.Error => LogLevel.Error,
+            MessageType.Warning => LogLevel.Warning,
+            _ => LogLevel.Trace
+        };
+
         LogLspEvent("logMessage", log.Message ?? string.Empty, level);
     }
 
@@ -546,7 +557,7 @@ public abstract class LanguageServiceLsp(string name, string? workspace) : Langu
 
     /// <summary>
     ///     Requests diagnostics for a document using the pull model (textDocument/diagnostic).
-    ///     Servers that only support pull diagnostics (like tsgo) never send publishDiagnostics for
+    ///     Servers that only support pull diagnostics (like the native tsc language server) never send publishDiagnostics for
     ///     source files, so they are requested here and forwarded to the regular diagnostics handling.
     /// </summary>
     private void RequestPullDiagnostics(string fullPath)
@@ -590,31 +601,25 @@ public abstract class LanguageServiceLsp(string name, string? workspace) : Langu
             var client = Client;
             if (client == null) return;
 
-            //The request is sent manually because the RelatedDocumentDiagnosticReport converter of
-            //OmniSharp.Extensions.LanguageServer.Protocol is not implemented and throws on deserialization
-            var report = await client
-                .SendRequest(TextDocumentNames.Diagnostics, new DocumentDiagnosticParams
-                {
-                    TextDocument = new TextDocumentIdentifier { Uri = fullPath },
-                    PreviousResultId = previousResultId
-                })
-                .Returning<JToken?>(cancellation.Token);
+            var report = await client.RequestDocumentDiagnostic(new DocumentDiagnosticParams
+            {
+                TextDocument = new TextDocumentIdentifier { Uri = fullPath },
+                PreviousResultId = previousResultId
+            }, cancellation.Token);
 
-            if (cancellation.IsCancellationRequested || report is not JObject reportObject) return;
+            if (cancellation.IsCancellationRequested || report == null) return;
 
-            HandlePullDiagnosticsReport(fullPath, reportObject);
+            HandlePullDiagnosticsReport(fullPath, report);
 
             //Servers may report diagnostics for other documents in the same response
-            if (reportObject["relatedDocuments"] is JObject relatedDocuments)
-                foreach (var relatedDocument in relatedDocuments.Properties())
-                {
-                    if (relatedDocument.Value is not JObject relatedReport) continue;
+            foreach (var (relatedUri, relatedReport) in report.RelatedDocuments ??
+                                                        ImmutableDictionary<DocumentUri, DocumentDiagnosticReport>.Empty)
+            {
+                var relatedPath = relatedUri.GetFileSystemPath();
+                if (relatedPath == null) continue;
 
-                    var relatedPath = DocumentUri.From(relatedDocument.Name).GetFileSystemPath();
-                    if (relatedPath == null) continue;
-
-                    HandlePullDiagnosticsReport(relatedPath, relatedReport);
-                }
+                HandlePullDiagnosticsReport(relatedPath, relatedReport);
+            }
         }
         catch (OperationCanceledException)
         {
@@ -637,26 +642,30 @@ public abstract class LanguageServiceLsp(string name, string? workspace) : Langu
     }
 
     /// <summary>
-    ///     Parses a single document diagnostic report. An unchanged report means the previously
+    ///     Handles a single document diagnostic report. An unchanged report means the previously
     ///     published diagnostics are still valid, so only the result id is updated.
     /// </summary>
-    private void HandlePullDiagnosticsReport(string fullPath, JObject report)
+    private void HandlePullDiagnosticsReport(string fullPath, IDiagnosticReport report)
     {
-        var resultId = report["resultId"]?.Value<string>();
+        //Full and unchanged reports exist once for the requested document and once for related documents
+        var (resultId, items) = report switch
+        {
+            IFullDocumentDiagnosticReport full => (full.ResultId, full.Items),
+            IUnchangedDocumentDiagnosticReport unchanged => (unchanged.ResultId, null),
+            _ => (null, null)
+        };
 
         lock (_pullDiagnosticsRequests)
         {
             _pullDiagnosticsResultIds[fullPath] = resultId;
         }
 
-        if (report["kind"]?.Value<string>() == "unchanged") return;
-
-        var items = report["items"]?.ToObject<List<Diagnostic>>(LspSerializer.Instance.JsonSerializer);
+        if (items is null) return;
 
         PublishDiag(new PublishDiagnosticsParams
         {
             Uri = fullPath,
-            Diagnostics = new Container<Diagnostic>(items ?? [])
+            Diagnostics = items
         });
     }
 
@@ -941,9 +950,9 @@ public abstract class LanguageServiceLsp(string name, string? workspace) : Langu
 
             return ca;
         }
-        catch
+        catch (Exception e)
         {
-            //ContainerLocator.Container.Resolve<ILogger>()?.Error(e.Message, e); Enable once bug fixed
+            ContainerLocator.Container.Resolve<ILogger>()?.Error(e.Message, e);
             return null;
         }
     }

--- a/src/OneWare.Essentials/LanguageService/LanguageServiceLsp.cs
+++ b/src/OneWare.Essentials/LanguageService/LanguageServiceLsp.cs
@@ -190,7 +190,8 @@ public abstract class LanguageServiceLsp(string name, string? workspace) : Langu
                 });
                 options.WithCapability(new HoverCapability
                 {
-                    ContentFormat = new Container<MarkupKind>(MarkupKind.PlainText, MarkupKind.Markdown)
+                    //Markdown first, servers glue the signature and the documentation together in plain text
+                    ContentFormat = new Container<MarkupKind>(MarkupKind.Markdown, MarkupKind.PlainText)
                 });
                 options.WithCapability(new PublishDiagnosticsCapability
                 {
@@ -241,7 +242,7 @@ public abstract class LanguageServiceLsp(string name, string? workspace) : Langu
                 {
                     SignatureInformation = new SignatureInformationCapabilityOptions
                     {
-                        DocumentationFormat = new Container<MarkupKind>(MarkupKind.PlainText),
+                        DocumentationFormat = new Container<MarkupKind>(MarkupKind.Markdown, MarkupKind.PlainText),
                         ParameterInformation = new SignatureParameterInformationCapabilityOptions
                         {
                             LabelOffsetSupport = true
@@ -272,7 +273,7 @@ public abstract class LanguageServiceLsp(string name, string? workspace) : Langu
                     CompletionItem = new CompletionItemCapabilityOptions
                     {
                         CommitCharactersSupport = false,
-                        DocumentationFormat = new Container<MarkupKind>(MarkupKind.PlainText),
+                        DocumentationFormat = new Container<MarkupKind>(MarkupKind.Markdown, MarkupKind.PlainText),
                         SnippetSupport = true,
                         PreselectSupport = true,
                         InsertReplaceSupport = true,
@@ -744,7 +745,7 @@ public abstract class LanguageServiceLsp(string name, string? workspace) : Langu
         CompletionTriggerKind triggerKind, string? triggerChar)
     {
         var cts = new CancellationTokenSource();
-        cts.CancelAfter(1000);
+        cts.CancelAfter(5000);
         if (Client?.ServerSettings.Capabilities.CompletionProvider == null) return null;
         try
         {

--- a/src/OneWare.Essentials/LanguageService/LanguageServiceMarkdown.cs
+++ b/src/OneWare.Essentials/LanguageService/LanguageServiceMarkdown.cs
@@ -1,0 +1,213 @@
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OneWare.Essentials.Extensions;
+using OneWare.Essentials.Models;
+
+namespace OneWare.Essentials.LanguageService;
+
+/// <summary>
+///     Turns what a language server reports about a symbol into the markdown that hover tips, completion
+///     tips and the overload insight display.
+/// </summary>
+public static class LanguageServiceMarkdown
+{
+    /// <summary>
+    ///     Separates the parts of a hover tip that come from different sources.
+    /// </summary>
+    public const string SectionSeparator = "\n\n---\n\n";
+
+    /// <summary>
+    ///     Renders the contents of a hover response. Markdown is passed through, everything else is escaped
+    ///     so that it shows up the way the server wrote it.
+    /// </summary>
+    public static string? BuildHoverText(Hover hover)
+    {
+        if (hover.Contents.HasMarkupContent)
+        {
+            var markup = hover.Contents.MarkupContent;
+            if (markup == null) return null;
+
+            var value = markup.Kind == MarkupKind.Markdown
+                ? markup.Value.Trim()
+                : StringOrMarkupContentExtensions.EscapeMarkdown(markup.Value).Trim();
+
+            return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+
+        if (hover.Contents is not { HasMarkedStrings: true, MarkedStrings: not null }) return null;
+
+        var segments = hover.Contents.MarkedStrings
+            .Select(marked => string.IsNullOrWhiteSpace(marked.Language)
+                ? StringOrMarkupContentExtensions.EscapeMarkdown(marked.Value).Trim()
+                : $"```{marked.Language}\n{marked.Value.Trim()}\n```")
+            .Where(segment => !string.IsNullOrWhiteSpace(segment))
+            .ToList();
+
+        return segments.Count > 0 ? string.Join("\n\n", segments) : null;
+    }
+
+    /// <summary>
+    ///     Renders the diagnostics under the cursor. Every diagnostic gets its severity and, if the server
+    ///     reported them, the source and the code it belongs to.
+    /// </summary>
+    public static string? FormatDiagnostics(IReadOnlyList<ErrorListItem> errors)
+    {
+        if (errors.Count == 0) return null;
+
+        var formatted = errors.Select(error =>
+        {
+            var description = StringOrMarkupContentExtensions.EscapeMarkdown(error.Description).Trim();
+            return $"**{error.Type}**{FormatDiagnosticOrigin(error)}  \n{description}";
+        });
+
+        return string.Join("\n\n", formatted);
+    }
+
+    private static string FormatDiagnosticOrigin(ErrorListItem error)
+    {
+        var source = string.IsNullOrWhiteSpace(error.Source) ? null : error.Source;
+        var code = string.IsNullOrWhiteSpace(error.Code) ? null : error.Code;
+
+        return (source, code) switch
+        {
+            (not null, not null) => $" `{source} {code}`",
+            (not null, null) => $" `{source}`",
+            (null, not null) => $" `{code}`",
+            _ => string.Empty
+        };
+    }
+
+    /// <summary>
+    ///     Builds the markdown shown next to the completion list. The type information the server sends as
+    ///     detail goes into a code block, followed by the documentation of the symbol.
+    /// </summary>
+    public static string? BuildCompletionDescription(CompletionItem completionItem, string languageId)
+    {
+        var sections = new List<string>();
+
+        if (IsDeprecated(completionItem)) sections.Add("**Deprecated**");
+
+        var hasDetail = !string.IsNullOrWhiteSpace(completionItem.Detail);
+        var signature = hasDetail
+            ? completionItem.Detail
+            : completionItem.Label + completionItem.LabelDetails?.Detail;
+
+        if (!string.IsNullOrWhiteSpace(signature))
+            sections.Add($"```{languageId}\n{signature.Trim()}\n```");
+
+        var origin = completionItem.LabelDetails?.Description;
+        if (!string.IsNullOrWhiteSpace(origin))
+            sections.Add(StringOrMarkupContentExtensions.EscapeMarkdown(origin).Trim());
+
+        var documentation = completionItem.Documentation.GetMarkdown();
+        if (!string.IsNullOrWhiteSpace(documentation)) sections.Add(documentation);
+
+        //Repeating the label the list already shows is not worth opening a tip for
+        if (sections.Count == 0 || (sections.Count == 1 && !hasDetail)) return null;
+
+        return string.Join("\n\n", sections);
+    }
+
+    public static bool IsDeprecated(CompletionItem completionItem)
+    {
+        return completionItem.Deprecated || (completionItem.Tags?.Contains(CompletionItemTag.Deprecated) ?? false);
+    }
+
+    /// <summary>
+    ///     Renders a signature with the parameter the caret is on in bold. The overload insight already uses
+    ///     the editor font, so no code fence is needed and the emphasis survives.
+    /// </summary>
+    public static string FormatSignatureLabel(SignatureInformation signature, ParameterInformation? activeParameter)
+    {
+        var label = signature.Label ?? string.Empty;
+
+        if (GetParameterRange(signature, activeParameter) is not { } range)
+            return StringOrMarkupContentExtensions.EscapeMarkdown(label);
+
+        var prefix = StringOrMarkupContentExtensions.EscapeMarkdown(label[..range.start]);
+        var active = StringOrMarkupContentExtensions.EscapeMarkdown(label[range.start..range.end]);
+        var suffix = StringOrMarkupContentExtensions.EscapeMarkdown(label[range.end..]);
+
+        return string.IsNullOrEmpty(active) ? prefix + suffix : $"{prefix}**{active}**{suffix}";
+    }
+
+    /// <summary>
+    ///     Renders the documentation of a signature, led by the parameter the caret is on.
+    /// </summary>
+    public static string? FormatSignatureDocumentation(SignatureInformation signature,
+        ParameterInformation? activeParameter)
+    {
+        var sections = new List<string>();
+
+        var parameterName = GetParameterLabelText(signature, activeParameter);
+        var parameterDocumentation = activeParameter?.Documentation.GetMarkdown();
+
+        if (!string.IsNullOrWhiteSpace(parameterName))
+        {
+            var name = StringOrMarkupContentExtensions.EscapeMarkdown(parameterName);
+            sections.Add(string.IsNullOrWhiteSpace(parameterDocumentation)
+                ? $"**{name}**"
+                : $"**{name}** — {parameterDocumentation}");
+        }
+        else if (!string.IsNullOrWhiteSpace(parameterDocumentation))
+        {
+            sections.Add(parameterDocumentation);
+        }
+
+        var documentation = signature.Documentation.GetMarkdown();
+        if (!string.IsNullOrWhiteSpace(documentation)) sections.Add(documentation);
+
+        return sections.Count > 0 ? string.Join("\n\n", sections) : null;
+    }
+
+    /// <summary>
+    ///     Resolves the parameter the caret is on. Servers report it either per signature or once for the
+    ///     whole request, so both are taken into account.
+    /// </summary>
+    public static ParameterInformation? GetActiveParameter(SignatureHelp signatureHelp,
+        SignatureInformation signature)
+    {
+        var parameters = signature.Parameters?.ToList();
+        if (parameters is not { Count: > 0 }) return null;
+
+        var index = signature.ActiveParameter ?? signatureHelp.ActiveParameter;
+        if (index is not { } value || value < 0 || value >= parameters.Count) return null;
+
+        return parameters[value];
+    }
+
+    /// <summary>
+    ///     Locates a parameter inside the label of its signature. A server either sends the parameter text
+    ///     itself or, when it announced offset support, the range it covers in the signature label.
+    /// </summary>
+    public static (int start, int end)? GetParameterRange(SignatureInformation signature,
+        ParameterInformation? parameter)
+    {
+        if (parameter == null) return null;
+
+        var label = signature.Label ?? string.Empty;
+
+        if (parameter.Label.IsRange)
+        {
+            var (start, end) = parameter.Label.Range;
+            return start >= 0 && end <= label.Length && start < end ? (start, end) : null;
+        }
+
+        if (!parameter.Label.IsLabel || string.IsNullOrEmpty(parameter.Label.Label)) return null;
+
+        var index = label.IndexOf(parameter.Label.Label, StringComparison.Ordinal);
+        return index >= 0 ? (index, index + parameter.Label.Label.Length) : null;
+    }
+
+    /// <summary>
+    ///     Reads the text of a parameter, resolving offsets against the label of its signature.
+    /// </summary>
+    public static string? GetParameterLabelText(SignatureInformation signature, ParameterInformation? parameter)
+    {
+        if (parameter == null) return null;
+
+        if (GetParameterRange(signature, parameter) is { } range)
+            return (signature.Label ?? string.Empty)[range.start..range.end];
+
+        return parameter.Label.IsLabel ? parameter.Label.Label : null;
+    }
+}

--- a/src/OneWare.Essentials/LanguageService/TypeAssistanceLanguageService.cs
+++ b/src/OneWare.Essentials/LanguageService/TypeAssistanceLanguageService.cs
@@ -765,7 +765,7 @@ public abstract class TypeAssistanceLanguageService : TypeAssistanceBase
         {
             var (signature, activeParam) = FormatSignatureLabel(s);
             
-            var docs = ExtractDocumentation(s.Documentation);
+            var docs = s.Documentation.GetPlainText();
             string? activeParamSection = null;
 
             if (s.Parameters is not null && s.ActiveParameter.HasValue)
@@ -774,7 +774,7 @@ public abstract class TypeAssistanceLanguageService : TypeAssistanceBase
                 if (index >= 0 && index < s.Parameters.Count())
                 {
                     var param = s.Parameters.ElementAt(index);
-                    var paramDoc = ExtractDocumentation(param.Documentation);
+                    var paramDoc = param.Documentation.GetPlainText();
                     
                     // Always show active parameter indicator
                     if (!string.IsNullOrWhiteSpace(activeParam))
@@ -835,7 +835,7 @@ public abstract class TypeAssistanceLanguageService : TypeAssistanceBase
             _ = ShowSignatureHelpAsync(SignatureHelpTriggerKind.Invoked, null, false, null);
         }
 
-        var description = ExtractDocumentation(comp.Documentation);
+        var description = comp.Documentation.GetPlainText();
         var insertText = comp.InsertText ?? comp.Label;
         var isSnippet = comp.InsertTextFormat == InsertTextFormat.Snippet;
         int? replaceStart = null;
@@ -843,17 +843,29 @@ public abstract class TypeAssistanceLanguageService : TypeAssistanceBase
 
         if (comp.TextEdit != null)
         {
+            // Ranges are guarded: a server that sends an edit the LSP library cannot map keeps the
+            // completion usable, it is then applied to the word in front of the caret instead.
             if (comp.TextEdit.IsTextEdit && comp.TextEdit.TextEdit != null)
             {
                 insertText = comp.TextEdit.TextEdit.NewText;
-                replaceStart = CodeBox.Document.GetOffsetFromPosition(comp.TextEdit.TextEdit.Range.Start) - 1;
-                replaceEnd = CodeBox.Document.GetOffsetFromPosition(comp.TextEdit.TextEdit.Range.End) - 1;
+
+                if (comp.TextEdit.TextEdit.Range != null)
+                {
+                    replaceStart = CodeBox.Document.GetOffsetFromPosition(comp.TextEdit.TextEdit.Range.Start) - 1;
+                    replaceEnd = CodeBox.Document.GetOffsetFromPosition(comp.TextEdit.TextEdit.Range.End) - 1;
+                }
             }
             else if (comp.TextEdit.IsInsertReplaceEdit && comp.TextEdit.InsertReplaceEdit != null)
             {
                 insertText = comp.TextEdit.InsertReplaceEdit.NewText;
-                replaceStart = CodeBox.Document.GetOffsetFromPosition(comp.TextEdit.InsertReplaceEdit.Replace.Start) - 1;
-                replaceEnd = CodeBox.Document.GetOffsetFromPosition(comp.TextEdit.InsertReplaceEdit.Replace.End) - 1;
+
+                var range = comp.TextEdit.InsertReplaceEdit.Replace ?? comp.TextEdit.InsertReplaceEdit.Insert;
+
+                if (range != null)
+                {
+                    replaceStart = CodeBox.Document.GetOffsetFromPosition(range.Start) - 1;
+                    replaceEnd = CodeBox.Document.GetOffsetFromPosition(range.End) - 1;
+                }
             }
         }
 
@@ -866,14 +878,6 @@ public abstract class TypeAssistanceLanguageService : TypeAssistanceBase
             ReplaceStartOffset = replaceStart,
             ReplaceEndOffset = replaceEnd
         };
-    }
-
-    private static string? ExtractDocumentation(StringOrMarkupContent? documentation)
-    {
-        if (documentation == null) return null;
-        if (documentation.HasMarkupContent) return documentation.MarkupContent?.Value;
-        if (documentation.HasString) return documentation.String;
-        return null;
     }
 
     protected virtual (string signature, string? activeParam) FormatSignatureLabel(SignatureInformation signature)

--- a/src/OneWare.Essentials/LanguageService/TypeAssistanceLanguageService.cs
+++ b/src/OneWare.Essentials/LanguageService/TypeAssistanceLanguageService.cs
@@ -68,47 +68,37 @@ public abstract class TypeAssistanceLanguageService : TypeAssistanceBase
 
         var pos = CodeBox.Document.GetLocation(offset);
 
-        var error = ContainerLocator.Container.Resolve<IErrorService>().GetErrorsForFile(CurrentFilePath)
+        var errors = ContainerLocator.Container.Resolve<IErrorService>().GetErrorsForFile(CurrentFilePath)
+            .Where(error => pos.Line >= error.StartLine
+                            && pos.Line <= error.EndLine
+                            && pos.Column >= error.StartColumn
+                            && pos.Column <= error.EndColumn)
             .OrderBy(x => x.Type)
-            .FirstOrDefault(error => pos.Line >= error.StartLine
-                                     && pos.Line <= error.EndLine
-                                     && pos.Column >= error.StartColumn
-                                     && pos.Column <= error.EndColumn);
-        var parts = new List<string>();
-        if (error != null) parts.Add(error.Description);
+            .ToList();
+
+        var sections = new List<string>();
+
+        var diagnostics = FormatDiagnostics(errors);
+        if (diagnostics != null) sections.Add(diagnostics);
 
         var hover = await Service.RequestHoverAsync(CurrentFilePath,
             new Position(pos.Line - 1, pos.Column - 1));
         if (hover != null)
         {
-            var hoverText = BuildHoverText(hover);
-            if (!string.IsNullOrWhiteSpace(hoverText)) parts.Add(hoverText);
+            var hoverText = LanguageServiceMarkdown.BuildHoverText(hover);
+            if (!string.IsNullOrWhiteSpace(hoverText)) sections.Add(hoverText);
         }
 
-        var info = string.Join("\n\n", parts);
-        return string.IsNullOrWhiteSpace(info) ? null : info;
+        //A rule keeps the diagnostics apart from what the language server has to say about the symbol
+        return sections.Count > 0 ? string.Join(LanguageServiceMarkdown.SectionSeparator, sections) : null;
     }
 
-    private static string? BuildHoverText(Hover hover)
+    /// <summary>
+    ///     Renders the diagnostics under the cursor as markdown.
+    /// </summary>
+    protected virtual string? FormatDiagnostics(IReadOnlyList<ErrorListItem> errors)
     {
-        if (hover.Contents.HasMarkupContent)
-            return hover.Contents.MarkupContent?.Value;
-
-        if (hover.Contents is { HasMarkedStrings: true, MarkedStrings: not null })
-        {
-            var segments = new List<string>();
-            foreach (var marked in hover.Contents.MarkedStrings)
-            {
-                if (!string.IsNullOrWhiteSpace(marked.Language))
-                    segments.Add($"```{marked.Language}\n{marked.Value}\n```");
-                else
-                    segments.Add(marked.Value);
-            }
-
-            return segments.Count > 0 ? string.Join("\n\n", segments) : null;
-        }
-
-        return null;
+        return LanguageServiceMarkdown.FormatDiagnostics(errors);
     }
 
     public override async Task<List<MenuItemModel>?> GetQuickMenuAsync(int offset)
@@ -586,8 +576,9 @@ public abstract class TypeAssistanceLanguageService : TypeAssistanceBase
             OverloadInsight.SetValue(TextBlock.FontSizeProperty,
                 SettingsService.GetSettingValue<int>("Editor_FontSize"));
             
-            // Restore previous selected index if retriggering and valid
-            if (retrigger && previousSelectedIndex > 0 && previousSelectedIndex < overloadProvider.Count)
+            // Restore previous selected index if retriggering and valid, unless the server picked an overload
+            if (retrigger && previousSelectedIndex > 0 && previousSelectedIndex < overloadProvider.Count &&
+                signatureHelp.ActiveSignature is null)
             {
                 overloadProvider.SelectedIndex = previousSelectedIndex;
             }
@@ -740,7 +731,7 @@ public abstract class TypeAssistanceLanguageService : TypeAssistanceBase
             var resolvedCi = await Service.ResolveCompletionItemAsync(selectedItem.CompletionItemLsp);
             if (resolvedCi != null && IsOpen && Completion.IsOpen)
             {
-                var cc = ConvertCompletionItem(resolvedCi, selectedItem.CompletionOffset);
+                var cc = ConvertCompletionItem(resolvedCi, selectedItem.CompletionOffset, selectedItem.Priority);
                 var cindex = Completion.CompletionList.CompletionData.IndexOf(selectedItem);
                 if (cindex >= 0)
                 {
@@ -760,51 +751,22 @@ public abstract class TypeAssistanceLanguageService : TypeAssistanceBase
     protected virtual OverloadProvider ConvertOverloadProvider(SignatureHelp signatureHelp)
     {
         var overloadOptions = new List<(string, string?)>();
-        
+
         foreach (var s in signatureHelp.Signatures)
         {
-            var (signature, activeParam) = FormatSignatureLabel(s);
-            
-            var docs = s.Documentation.GetPlainText();
-            string? activeParamSection = null;
+            var activeParameter = LanguageServiceMarkdown.GetActiveParameter(signatureHelp, s);
 
-            if (s.Parameters is not null && s.ActiveParameter.HasValue)
-            {
-                var index = s.ActiveParameter.Value;
-                if (index >= 0 && index < s.Parameters.Count())
-                {
-                    var param = s.Parameters.ElementAt(index);
-                    var paramDoc = param.Documentation.GetPlainText();
-                    
-                    // Always show active parameter indicator
-                    if (!string.IsNullOrWhiteSpace(activeParam))
-                    {
-                        activeParamSection = !string.IsNullOrWhiteSpace(paramDoc) 
-                            ? $"**{activeParam}**: {paramDoc}" 
-                            : $"**{activeParam}**";
-                    }
-                    else if (!string.IsNullOrWhiteSpace(paramDoc))
-                    {
-                        activeParamSection = paramDoc;
-                    }
-                }
-            }
-
-            // Combine documentation sections
-            var combinedDocs = new List<string>();
-            if (!string.IsNullOrWhiteSpace(activeParamSection))
-                combinedDocs.Add(activeParamSection);
-            if (!string.IsNullOrWhiteSpace(docs))
-                combinedDocs.Add(docs);
-            
-            var finalDocs = combinedDocs.Count > 0 ? string.Join("\n\n---\n\n", combinedDocs) : null;
-
-            overloadOptions.Add((signature, finalDocs));
+            overloadOptions.Add((FormatSignatureLabel(s, activeParameter),
+                FormatSignatureDocumentation(s, activeParameter)));
         }
+
+        var activeSignature = signatureHelp.ActiveSignature ?? 0;
 
         return new OverloadProvider(overloadOptions)
         {
-            SignatureHelp = signatureHelp
+            SignatureHelp = signatureHelp,
+            //The server knows which overload matches what is already typed, so start out on that one
+            SelectedIndex = activeSignature >= 0 && activeSignature < overloadOptions.Count ? activeSignature : 0
         };
     }
 
@@ -835,7 +797,7 @@ public abstract class TypeAssistanceLanguageService : TypeAssistanceBase
             _ = ShowSignatureHelpAsync(SignatureHelpTriggerKind.Invoked, null, false, null);
         }
 
-        var description = comp.Documentation.GetPlainText();
+        var description = BuildCompletionDescription(comp);
         var insertText = comp.InsertText ?? comp.Label;
         var isSnippet = comp.InsertTextFormat == InsertTextFormat.Snippet;
         int? replaceStart = null;
@@ -875,35 +837,43 @@ public abstract class TypeAssistanceLanguageService : TypeAssistanceBase
         {
             FilterText = comp.FilterText,
             SortText = comp.SortText,
+            LabelDetail = comp.LabelDetails?.Detail,
+            LabelDescription = comp.LabelDetails?.Description,
+            IsDeprecated = LanguageServiceMarkdown.IsDeprecated(comp),
             ReplaceStartOffset = replaceStart,
             ReplaceEndOffset = replaceEnd
         };
     }
 
-    protected virtual (string signature, string? activeParam) FormatSignatureLabel(SignatureInformation signature)
-    {
-        var label = signature.Label ?? string.Empty;
-        string? activeParamText = null;
-        
-        if (signature.Parameters is not null && signature.ActiveParameter.HasValue)
-        {
-            var index = signature.ActiveParameter.Value;
-            if (index >= 0 && index < signature.Parameters.Count())
-            {
-                var param = signature.Parameters.ElementAt(index);
-                activeParamText = GetParameterLabelText(param.Label);
-            }
-        }
-
-        // Format as fenced code block for syntax highlighting
-        var languageId = GetLanguageIdForMarkdown();
-        var formatted = $"```{languageId}\n{label}\n```";
-
-        return (formatted, activeParamText);
-    }
-    
     /// <summary>
-    /// Gets the language identifier for markdown code blocks based on the current file extension.
+    ///     Builds the markdown shown next to the completion list.
+    /// </summary>
+    protected virtual string? BuildCompletionDescription(CompletionItem comp)
+    {
+        return LanguageServiceMarkdown.BuildCompletionDescription(comp, GetLanguageIdForMarkdown());
+    }
+
+
+    /// <summary>
+    ///     Renders the signature with the parameter the caret is on in bold.
+    /// </summary>
+    protected virtual string FormatSignatureLabel(SignatureInformation signature,
+        ParameterInformation? activeParameter)
+    {
+        return LanguageServiceMarkdown.FormatSignatureLabel(signature, activeParameter);
+    }
+
+    /// <summary>
+    ///     Renders the documentation of a signature, led by the parameter the caret is on.
+    /// </summary>
+    protected virtual string? FormatSignatureDocumentation(SignatureInformation signature,
+        ParameterInformation? activeParameter)
+    {
+        return LanguageServiceMarkdown.FormatSignatureDocumentation(signature, activeParameter);
+    }
+
+    /// <summary>
+    ///     Gets the language identifier for markdown code blocks based on the current file extension.
     /// </summary>
     protected virtual string GetLanguageIdForMarkdown()
     {
@@ -927,14 +897,6 @@ public abstract class TypeAssistanceLanguageService : TypeAssistanceBase
             "java" => "java",
             _ => extension ?? ""
         };
-    }
-
-    private static string? GetParameterLabelText(object? label)
-    {
-        if (label == null) return null;
-        if (label is string text) return text;
-        var asString = label.ToString();
-        return string.IsNullOrWhiteSpace(asString) ? null : asString;
     }
 
     public ErrorListItem? GetErrorAtLocation(TextLocation location)

--- a/src/OneWare.Essentials/PackageManager/PackageStateExtensions.cs
+++ b/src/OneWare.Essentials/PackageManager/PackageStateExtensions.cs
@@ -20,9 +20,7 @@ public static class PackageStateExtensions
 
         return state.Package.Versions?
             .Where(x => (includePrerelease || !x.IsPrerelease) && x.IsSupportedByStudio())
-            .OrderByDescending(x => Version.TryParse(x.Version, out var parsed) ? parsed : EmptyVersion)
+            .OrderByDescending(x => SemanticVersion.TryParse(x.Version, out var parsed) ? parsed : SemanticVersion.Empty)
             .FirstOrDefault();
     }
-
-    private static readonly Version EmptyVersion = new(0, 0);
 }

--- a/src/OneWare.Essentials/PackageManager/SemanticVersion.cs
+++ b/src/OneWare.Essentials/PackageManager/SemanticVersion.cs
@@ -1,0 +1,160 @@
+using System.Globalization;
+
+namespace OneWare.Essentials.PackageManager;
+
+/// <summary>
+///     Semantic version of a package, e.g. <c>7.0.0-dev.20260707.2</c>.
+///     <see cref="System.Version" /> cannot parse prerelease or build metadata suffixes, which would make
+///     installed prerelease packages look like they were never installed.
+/// </summary>
+public sealed class SemanticVersion : IComparable<SemanticVersion>, IEquatable<SemanticVersion>
+{
+    private SemanticVersion(int[] numbers, string[] prereleaseIdentifiers)
+    {
+        _numbers = numbers;
+        _prereleaseIdentifiers = prereleaseIdentifiers;
+    }
+
+    private readonly int[] _numbers;
+    private readonly string[] _prereleaseIdentifiers;
+
+    public bool IsPrerelease => _prereleaseIdentifiers.Length > 0;
+
+    /// <summary>
+    ///     Parses a version like <c>1.2</c>, <c>1.2.3.4</c>, <c>1.2.3-beta.1</c> or <c>1.2.3-beta+build.5</c>.
+    ///     Build metadata is ignored, as required by semver.
+    /// </summary>
+    public static bool TryParse(string? version, out SemanticVersion result)
+    {
+        result = Empty;
+
+        if (string.IsNullOrWhiteSpace(version)) return false;
+
+        var span = version.Trim();
+
+        if (span.StartsWith('v') || span.StartsWith('V')) span = span[1..];
+
+        var buildIndex = span.IndexOf('+');
+        if (buildIndex >= 0) span = span[..buildIndex];
+
+        var prereleaseIndex = span.IndexOf('-');
+        var prerelease = prereleaseIndex >= 0 ? span[(prereleaseIndex + 1)..] : string.Empty;
+        if (prereleaseIndex >= 0)
+        {
+            if (prerelease.Length == 0) return false;
+            span = span[..prereleaseIndex];
+        }
+
+        if (span.Length == 0) return false;
+
+        var parts = span.Split('.');
+        var numbers = new int[parts.Length];
+
+        for (var i = 0; i < parts.Length; i++)
+        {
+            if (!int.TryParse(parts[i], NumberStyles.None, CultureInfo.InvariantCulture, out var number))
+                return false;
+
+            numbers[i] = number;
+        }
+
+        var identifiers = prerelease.Length == 0
+            ? []
+            : prerelease.Split('.');
+
+        if (identifiers.Any(string.IsNullOrEmpty)) return false;
+
+        result = new SemanticVersion(numbers, identifiers);
+        return true;
+    }
+
+    public static readonly SemanticVersion Empty = new([], []);
+
+    public int CompareTo(SemanticVersion? other)
+    {
+        if (other == null) return 1;
+
+        var length = Math.Max(_numbers.Length, other._numbers.Length);
+        for (var i = 0; i < length; i++)
+        {
+            var mine = i < _numbers.Length ? _numbers[i] : 0;
+            var theirs = i < other._numbers.Length ? other._numbers[i] : 0;
+
+            if (mine != theirs) return mine.CompareTo(theirs);
+        }
+
+        // A version without a prerelease suffix outranks the prereleases leading up to it.
+        if (_prereleaseIdentifiers.Length == 0 && other._prereleaseIdentifiers.Length == 0) return 0;
+        if (_prereleaseIdentifiers.Length == 0) return 1;
+        if (other._prereleaseIdentifiers.Length == 0) return -1;
+
+        var identifierCount = Math.Min(_prereleaseIdentifiers.Length, other._prereleaseIdentifiers.Length);
+        for (var i = 0; i < identifierCount; i++)
+        {
+            var comparison = CompareIdentifier(_prereleaseIdentifiers[i], other._prereleaseIdentifiers[i]);
+            if (comparison != 0) return comparison;
+        }
+
+        return _prereleaseIdentifiers.Length.CompareTo(other._prereleaseIdentifiers.Length);
+    }
+
+    private static int CompareIdentifier(string left, string right)
+    {
+        var leftIsNumeric = int.TryParse(left, NumberStyles.None, CultureInfo.InvariantCulture, out var leftNumber);
+        var rightIsNumeric = int.TryParse(right, NumberStyles.None, CultureInfo.InvariantCulture, out var rightNumber);
+
+        if (leftIsNumeric && rightIsNumeric) return leftNumber.CompareTo(rightNumber);
+        if (leftIsNumeric) return -1;
+        if (rightIsNumeric) return 1;
+
+        return string.CompareOrdinal(left, right);
+    }
+
+    public bool Equals(SemanticVersion? other)
+    {
+        return CompareTo(other) == 0;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is SemanticVersion other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (var number in _numbers) hash.Add(number);
+        foreach (var identifier in _prereleaseIdentifiers) hash.Add(identifier);
+        return hash.ToHashCode();
+    }
+
+    public static bool operator >(SemanticVersion? left, SemanticVersion? right)
+    {
+        return Comparer<SemanticVersion>.Default.Compare(left, right) > 0;
+    }
+
+    public static bool operator <(SemanticVersion? left, SemanticVersion? right)
+    {
+        return Comparer<SemanticVersion>.Default.Compare(left, right) < 0;
+    }
+
+    public static bool operator >=(SemanticVersion? left, SemanticVersion? right)
+    {
+        return Comparer<SemanticVersion>.Default.Compare(left, right) >= 0;
+    }
+
+    public static bool operator <=(SemanticVersion? left, SemanticVersion? right)
+    {
+        return Comparer<SemanticVersion>.Default.Compare(left, right) <= 0;
+    }
+
+    public static bool operator ==(SemanticVersion? left, SemanticVersion? right)
+    {
+        return Comparer<SemanticVersion>.Default.Compare(left, right) == 0;
+    }
+
+    public static bool operator !=(SemanticVersion? left, SemanticVersion? right)
+    {
+        return !(left == right);
+    }
+}

--- a/src/OneWare.PackageManager/Services/PackageService.cs
+++ b/src/OneWare.PackageManager/Services/PackageService.cs
@@ -312,6 +312,12 @@ public class PackageService : ObservableObject, IPackageService, IDisposable
 
             await SaveInstalledPackagesAsync();
 
+            // A package that no repository offers anymore only existed as a stub for its installation.
+            // Once it is removed there is nothing left to show or install, so it is dropped entirely.
+            if (!_catalog.Manifests.ContainsKey(packageId)) _packages.Remove(packageId);
+
+            PackagesUpdated?.Invoke(this, EventArgs.Empty);
+
             return true;
         }
         catch (Exception e)
@@ -664,8 +670,16 @@ public class PackageService : ObservableObject, IPackageService, IDisposable
 
         var target = state.ResolveTargetVersion();
 
-        var hasTarget = Version.TryParse(target?.Version, out var targetVersion);
-        var hasInstalled = Version.TryParse(state.InstalledVersion?.Version ?? "", out var installedVersion);
+        var hasTarget = SemanticVersion.TryParse(target?.Version, out var targetVersion);
+        var hasInstalled = SemanticVersion.TryParse(state.InstalledVersion?.Version, out var installedVersion);
+
+        // An installed package stays removable even when its version string cannot be parsed or the
+        // package disappeared from every repository, otherwise it can never be uninstalled again.
+        if (!hasInstalled && state.InstalledVersion != null)
+        {
+            state.Status = PackageStatus.Installed;
+            return;
+        }
 
         if (hasInstalled && hasTarget && targetVersion > installedVersion)
             state.Status = target!.IsPrerelease

--- a/src/OneWare.PackageManager/ViewModels/PackageViewModel.cs
+++ b/src/OneWare.PackageManager/ViewModels/PackageViewModel.cs
@@ -144,8 +144,8 @@ public class PackageViewModel : PackageListEntryViewModel
             PackageVersionModels.AddRange(PackageState.Package.Versions
                 .OrderByDescending(x =>
                 {
-                    if (Version.TryParse(x.Version, out var v)) return v;
-                    return new Version(int.MaxValue, 0);
+                    if (SemanticVersion.TryParse(x.Version, out var v)) return v;
+                    return SemanticVersion.Empty;
                 })
                 .Select(x => new PackageVersionModel(x)));
 
@@ -166,8 +166,8 @@ public class PackageViewModel : PackageListEntryViewModel
 
     private void UpdateStatus()
     {
-        Version.TryParse(SelectedVersionModel?.Version.Version ?? "", out var sV);
-        Version.TryParse(PackageState.InstalledVersion?.Version ?? "", out var iV);
+        SemanticVersion.TryParse(SelectedVersionModel?.Version.Version, out var sV);
+        SemanticVersion.TryParse(PackageState.InstalledVersion?.Version, out var iV);
 
         MainButtonCommand = null;
         var primaryButtonBrushObservable = Application.Current!.GetResourceObservable("ThemeBorderMidBrush");
@@ -194,6 +194,10 @@ public class PackageViewModel : PackageListEntryViewModel
                 PrimaryButtonText = "Cancel";
                 MainButtonCommand = CancelCommand;
                 primaryButtonBrushObservable = Application.Current!.GetResourceObservable("ThemeControlMidBrush");
+                break;
+            case PackageStatus.Unavailable when PackageState.InstalledVersion != null:
+                PrimaryButtonText = "Remove";
+                MainButtonCommand = RemoveCommand;
                 break;
             case PackageStatus.Unavailable:
                 PrimaryButtonText = "Unavailable";

--- a/src/OneWare.TypeScript/LanguageServiceTypeScript.cs
+++ b/src/OneWare.TypeScript/LanguageServiceTypeScript.cs
@@ -9,7 +9,7 @@ public class LanguageServiceTypeScript : LanguageServiceLspAutoDownload
     public LanguageServiceTypeScript(string workspace, ISettingsService settingsService,
         IPackageService packageService)
         : base(settingsService.GetSettingObservable<string>(TypeScriptModule.LspPathSetting),
-            TypeScriptModule.TsgoPackage, TypeScriptModule.LspName, workspace, packageService,
+            TypeScriptModule.TypeScriptPackage, TypeScriptModule.LspName, workspace, packageService,
             settingsService.GetSettingObservable<bool>("Experimental_AutoDownloadBinaries"),
             arguments: "--lsp -stdio")
     {

--- a/src/OneWare.TypeScript/TypeScriptModule.cs
+++ b/src/OneWare.TypeScript/TypeScriptModule.cs
@@ -8,8 +8,8 @@ namespace OneWare.TypeScript;
 
 public class TypeScriptModule : OneWareModuleBase
 {
-    public const string LspName = "tsgo";
-    public const string LspPathSetting = "TypeScriptModule_TsgoPath";
+    public const string LspName = "tsc";
+    public const string LspPathSetting = "TypeScriptModule_TscPath";
 
     /// <summary>
     ///     Extensions handled by the language server. .mts/.cts are resolved through extension links.
@@ -17,14 +17,14 @@ public class TypeScriptModule : OneWareModuleBase
     public static readonly string[] SupportedExtensions =
         [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
 
-    private const string TsgoVersion = "7.0.0-dev.20260707.2";
+    private const string TypeScriptVersion = "7.0.2";
 
-    public static readonly Package TsgoPackage = new()
+    public static readonly Package TypeScriptPackage = new()
     {
         Category = "Binaries",
-        Id = "tsgo",
+        Id = "typescript",
         Type = "NativeTool",
-        Name = "TypeScript Native Preview (tsgo)",
+        Name = "TypeScript (native tsc)",
         Description = "Used for JavaScript and TypeScript Support",
         License = "Apache 2.0",
         IconUrl = "https://raw.githubusercontent.com/lobehub/lobe-icons/refs/heads/master/packages/static-png/dark/typescript.png",
@@ -33,7 +33,7 @@ public class TypeScriptModule : OneWareModuleBase
             new PackageLink
             {
                 Name = "GitHub",
-                Url = "https://github.com/microsoft/typescript-go"
+                Url = "https://github.com/microsoft/TypeScript"
             }
         ],
         Tabs =
@@ -41,26 +41,26 @@ public class TypeScriptModule : OneWareModuleBase
             new PackageTab
             {
                 Title = "License",
-                ContentUrl = "https://raw.githubusercontent.com/microsoft/typescript-go/main/LICENSE"
+                ContentUrl = "https://raw.githubusercontent.com/microsoft/TypeScript/main/LICENSE.txt"
             }
         ],
         Versions =
         [
             new PackageVersion
             {
-                Version = TsgoVersion,
+                Version = TypeScriptVersion,
                 Targets =
                 [
                     new PackageTarget
                     {
                         Target = "win-x64",
                         Url =
-                            $"https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-{TsgoVersion}.tgz",
+                            $"https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-{TypeScriptVersion}.tgz",
                         AutoSetting =
                         [
                             new PackageAutoSetting
                             {
-                                RelativePath = Path.Combine("package", "lib", "tsgo.exe"),
+                                RelativePath = Path.Combine("package", "lib", "tsc.exe"),
                                 SettingKey = LspPathSetting
                             }
                         ]
@@ -69,12 +69,12 @@ public class TypeScriptModule : OneWareModuleBase
                     {
                         Target = "win-arm64",
                         Url =
-                            $"https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-{TsgoVersion}.tgz",
+                            $"https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-{TypeScriptVersion}.tgz",
                         AutoSetting =
                         [
                             new PackageAutoSetting
                             {
-                                RelativePath = Path.Combine("package", "lib", "tsgo.exe"),
+                                RelativePath = Path.Combine("package", "lib", "tsc.exe"),
                                 SettingKey = LspPathSetting
                             }
                         ]
@@ -83,12 +83,12 @@ public class TypeScriptModule : OneWareModuleBase
                     {
                         Target = "linux-x64",
                         Url =
-                            $"https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-{TsgoVersion}.tgz",
+                            $"https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-{TypeScriptVersion}.tgz",
                         AutoSetting =
                         [
                             new PackageAutoSetting
                             {
-                                RelativePath = "package/lib/tsgo",
+                                RelativePath = "package/lib/tsc",
                                 SettingKey = LspPathSetting
                             }
                         ]
@@ -97,12 +97,12 @@ public class TypeScriptModule : OneWareModuleBase
                     {
                         Target = "linux-arm64",
                         Url =
-                            $"https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-{TsgoVersion}.tgz",
+                            $"https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-{TypeScriptVersion}.tgz",
                         AutoSetting =
                         [
                             new PackageAutoSetting
                             {
-                                RelativePath = "package/lib/tsgo",
+                                RelativePath = "package/lib/tsc",
                                 SettingKey = LspPathSetting
                             }
                         ]
@@ -111,12 +111,12 @@ public class TypeScriptModule : OneWareModuleBase
                     {
                         Target = "osx-x64",
                         Url =
-                            $"https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-{TsgoVersion}.tgz",
+                            $"https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-{TypeScriptVersion}.tgz",
                         AutoSetting =
                         [
                             new PackageAutoSetting
                             {
-                                RelativePath = "package/lib/tsgo",
+                                RelativePath = "package/lib/tsc",
                                 SettingKey = LspPathSetting
                             }
                         ]
@@ -125,12 +125,12 @@ public class TypeScriptModule : OneWareModuleBase
                     {
                         Target = "osx-arm64",
                         Url =
-                            $"https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-{TsgoVersion}.tgz",
+                            $"https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-{TypeScriptVersion}.tgz",
                         AutoSetting =
                         [
                             new PackageAutoSetting
                             {
-                                RelativePath = "package/lib/tsgo",
+                                RelativePath = "package/lib/tsc",
                                 SettingKey = LspPathSetting
                             }
                         ]
@@ -146,14 +146,14 @@ public class TypeScriptModule : OneWareModuleBase
 
     public override void Initialize(IServiceProvider serviceProvider)
     {
-        serviceProvider.Resolve<IPackageService>().RegisterPackage(TsgoPackage);
+        serviceProvider.Resolve<IPackageService>().RegisterPackage(TypeScriptPackage);
 
         serviceProvider.Resolve<ISettingsService>().RegisterSetting("Languages", "TypeScript", LspPathSetting,
-            new FilePathSetting("tsgo Path", "", null,
+            new FilePathSetting("tsc Path", "", null,
                 serviceProvider.Resolve<IPaths>().NativeToolsDirectory, PlatformHelper.ExistsOnPath,
                 PlatformHelper.ExeFile)
             {
-                HoverDescription = "Path for the tsgo executable"
+                HoverDescription = "Path for the native tsc executable"
             });
 
         serviceProvider.Resolve<IErrorService>().RegisterErrorSource(LspName);

--- a/tests/OneWare.Essentials.UnitTests/CompletionItemDeserializationTests.cs
+++ b/tests/OneWare.Essentials.UnitTests/CompletionItemDeserializationTests.cs
@@ -1,0 +1,66 @@
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
+using Xunit;
+
+namespace OneWare.Essentials.UnitTests;
+
+/// <summary>
+///     Guards the completion text edits the client announces support for in
+///     <c>LanguageServiceLsp</c>. The upstream LSP library detected an InsertReplaceEdit by checking
+///     for a string "insert" property, which it never is, so such edits silently lost their ranges.
+/// </summary>
+public class CompletionItemDeserializationTests
+{
+    private readonly LspSerializer _serializer = new();
+
+    private const string InsertReplaceEditJson = """
+        {
+          "label": "myHelperFunction",
+          "kind": 3,
+          "textEdit": {
+            "newText": "myHelperFunction",
+            "insert": { "start": { "line": 1, "character": 0 }, "end": { "line": 1, "character": 12 } },
+            "replace": { "start": { "line": 1, "character": 0 }, "end": { "line": 1, "character": 12 } }
+          }
+        }
+        """;
+
+    private const string TextEditJson = """
+        {
+          "label": "aa",
+          "kind": 12,
+          "textEdit": {
+            "newText": "aa",
+            "range": { "start": { "line": 2, "character": 24 }, "end": { "line": 2, "character": 25 } }
+          }
+        }
+        """;
+
+    [Fact]
+    public void InsertReplaceEdit_KeepsItsRanges()
+    {
+        var item = _serializer.DeserializeObject<CompletionItem>(InsertReplaceEditJson);
+
+        Assert.NotNull(item.TextEdit);
+        Assert.True(item.TextEdit!.IsInsertReplaceEdit);
+        Assert.False(item.TextEdit.IsTextEdit);
+
+        var edit = item.TextEdit.InsertReplaceEdit!;
+        Assert.Equal(1, edit.Insert.Start.Line);
+        Assert.Equal(0, edit.Insert.Start.Character);
+        Assert.Equal(12, edit.Replace.End.Character);
+    }
+
+    [Fact]
+    public void TextEdit_KeepsItsRange()
+    {
+        var item = _serializer.DeserializeObject<CompletionItem>(TextEditJson);
+
+        Assert.NotNull(item.TextEdit);
+        Assert.True(item.TextEdit!.IsTextEdit);
+        Assert.NotNull(item.TextEdit.TextEdit!.Range);
+        Assert.Equal(2, item.TextEdit.TextEdit.Range.Start.Line);
+        Assert.Equal(24, item.TextEdit.TextEdit.Range.Start.Character);
+        Assert.Equal(25, item.TextEdit.TextEdit.Range.End.Character);
+    }
+}

--- a/tests/OneWare.Essentials.UnitTests/LanguageServiceMarkdownTests.cs
+++ b/tests/OneWare.Essentials.UnitTests/LanguageServiceMarkdownTests.cs
@@ -1,0 +1,286 @@
+using System.Collections.Generic;
+using System.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OneWare.Essentials.Enums;
+using OneWare.Essentials.Extensions;
+using OneWare.Essentials.LanguageService;
+using OneWare.Essentials.Models;
+using Xunit;
+
+namespace OneWare.Essentials.UnitTests;
+
+public class LanguageServiceMarkdownTests
+{
+    private static SignatureInformation Signature(string label, params ParameterInformation[] parameters)
+    {
+        return new SignatureInformation
+        {
+            Label = label,
+            Parameters = new Container<ParameterInformation>(parameters)
+        };
+    }
+
+    [Fact]
+    public void EscapeMarkdown_KeepsEmphasisCharactersVisible()
+    {
+        var escaped = StringOrMarkupContentExtensions.EscapeMarkdown("value_of_x is *not* 2 ~ 3");
+
+        Assert.Equal(@"value\_of\_x is \*not\* 2 \~ 3", escaped);
+    }
+
+    [Fact]
+    public void EscapeMarkdown_KeepsLineBreaks()
+    {
+        var escaped = StringOrMarkupContentExtensions.EscapeMarkdown("first\r\nsecond");
+
+        //Two trailing spaces are what makes the renderer break the line
+        Assert.Equal("first  \nsecond", escaped);
+    }
+
+    [Fact]
+    public void GetMarkdown_PassesServerMarkdownThrough()
+    {
+        var content = new StringOrMarkupContent(new MarkupContent
+        {
+            Kind = MarkupKind.Markdown,
+            Value = "```ts\nconst a = 1;\n```\nMakes it **bold**.\n"
+        });
+
+        Assert.Equal("```ts\nconst a = 1;\n```\nMakes it **bold**.", content.GetMarkdown());
+    }
+
+    [Fact]
+    public void GetMarkdown_EscapesPlainTextDocumentation()
+    {
+        var content = new StringOrMarkupContent(new MarkupContent
+        {
+            Kind = MarkupKind.PlainText,
+            Value = "returns snake_case"
+        });
+
+        Assert.Equal(@"returns snake\_case", content.GetMarkdown());
+    }
+
+    [Fact]
+    public void GetMarkdown_ReturnsNullForEmptyDocumentation()
+    {
+        Assert.Null(new StringOrMarkupContent("   ").GetMarkdown());
+        Assert.Null(((StringOrMarkupContent?)null).GetMarkdown());
+    }
+
+    [Fact]
+    public void BuildHoverText_UsesFencesForMarkedStringsWithLanguage()
+    {
+        var hover = new Hover
+        {
+            Contents = new MarkedStringsOrMarkupContent(
+                new MarkedString("typescript", "function add(a: number): number"),
+                new MarkedString("Adds a number."))
+        };
+
+        Assert.Equal("```typescript\nfunction add(a: number): number\n```\n\nAdds a number.",
+            LanguageServiceMarkdown.BuildHoverText(hover));
+    }
+
+    [Fact]
+    public void FormatDiagnostics_ShowsSeverityAndOrigin()
+    {
+        var errors = new List<ErrorListItem>
+        {
+            new("Type 'string' is not assignable.", ErrorType.Error, "/a.ts", "typescript", 1, 1, 1, 5, "2322"),
+            new("Value is never read.", ErrorType.Hint, "/a.ts", null, 1, 1, 1, 5)
+        };
+
+        Assert.Equal("**Error** `typescript 2322`  \nType 'string' is not assignable.\n\n" +
+                     "**Hint**  \nValue is never read.",
+            LanguageServiceMarkdown.FormatDiagnostics(errors));
+    }
+
+    [Fact]
+    public void FormatDiagnostics_ReturnsNullWithoutDiagnostics()
+    {
+        Assert.Null(LanguageServiceMarkdown.FormatDiagnostics([]));
+    }
+
+    [Fact]
+    public void FormatSignatureLabel_HighlightsActiveParameterGivenAsText()
+    {
+        var signature = Signature("add(a: number, b: number): number",
+            new ParameterInformation { Label = "a: number" },
+            new ParameterInformation { Label = "b: number" });
+
+        var formatted = LanguageServiceMarkdown.FormatSignatureLabel(signature,
+            signature.Parameters!.ElementAt(1));
+
+        Assert.Equal("add(a: number, **b: number**): number", formatted);
+    }
+
+    [Fact]
+    public void FormatSignatureLabel_HighlightsActiveParameterGivenAsOffsets()
+    {
+        var signature = Signature("add(a: number, b: number): number",
+            new ParameterInformation { Label = (4, 13) },
+            new ParameterInformation { Label = (15, 24) });
+
+        var formatted = LanguageServiceMarkdown.FormatSignatureLabel(signature,
+            signature.Parameters!.ElementAt(0));
+
+        Assert.Equal("add(**a: number**, b: number): number", formatted);
+    }
+
+    [Fact]
+    public void FormatSignatureLabel_EscapesLabelWithoutActiveParameter()
+    {
+        var signature = Signature("read_all(path_name: string): string");
+
+        Assert.Equal(@"read\_all(path\_name: string): string",
+            LanguageServiceMarkdown.FormatSignatureLabel(signature, null));
+    }
+
+    [Fact]
+    public void FormatSignatureLabel_IgnoresOffsetsOutsideTheLabel()
+    {
+        var signature = Signature("add(a)", new ParameterInformation { Label = (4, 99) });
+
+        Assert.Equal("add(a)", LanguageServiceMarkdown.FormatSignatureLabel(signature,
+            signature.Parameters!.ElementAt(0)));
+    }
+
+    [Fact]
+    public void GetActiveParameter_FallsBackToTheRequestWideIndex()
+    {
+        var signature = Signature("add(a: number, b: number)",
+            new ParameterInformation { Label = "a: number" },
+            new ParameterInformation { Label = "b: number" });
+
+        //Most servers only report the active parameter once for the whole request
+        var signatureHelp = new SignatureHelp
+        {
+            Signatures = new Container<SignatureInformation>(signature),
+            ActiveParameter = 1
+        };
+
+        Assert.Equal("b: number",
+            LanguageServiceMarkdown.GetActiveParameter(signatureHelp, signature)?.Label.Label);
+    }
+
+    [Fact]
+    public void GetActiveParameter_PrefersTheIndexOfTheSignature()
+    {
+        var signature = new SignatureInformation
+        {
+            Label = "add(a, b)",
+            ActiveParameter = 0,
+            Parameters = new Container<ParameterInformation>(
+                new ParameterInformation { Label = "a" },
+                new ParameterInformation { Label = "b" })
+        };
+
+        var signatureHelp = new SignatureHelp
+        {
+            Signatures = new Container<SignatureInformation>(signature),
+            ActiveParameter = 1
+        };
+
+        Assert.Equal("a", LanguageServiceMarkdown.GetActiveParameter(signatureHelp, signature)?.Label.Label);
+    }
+
+    [Fact]
+    public void GetActiveParameter_ReturnsNullForAnIndexOutOfRange()
+    {
+        var signature = Signature("add(a)", new ParameterInformation { Label = "a" });
+        var signatureHelp = new SignatureHelp
+        {
+            Signatures = new Container<SignatureInformation>(signature),
+            ActiveParameter = 5
+        };
+
+        Assert.Null(LanguageServiceMarkdown.GetActiveParameter(signatureHelp, signature));
+    }
+
+    [Fact]
+    public void FormatSignatureDocumentation_LeadsWithTheActiveParameter()
+    {
+        var signature = new SignatureInformation
+        {
+            Label = "add(a: number)",
+            Documentation = new StringOrMarkupContent(new MarkupContent
+            {
+                Kind = MarkupKind.Markdown, Value = "Adds two numbers."
+            }),
+            Parameters = new Container<ParameterInformation>(new ParameterInformation
+            {
+                Label = (4, 13),
+                Documentation = new StringOrMarkupContent(new MarkupContent
+                {
+                    Kind = MarkupKind.Markdown, Value = "The first number."
+                })
+            })
+        };
+
+        Assert.Equal("**a: number** — The first number.\n\nAdds two numbers.",
+            LanguageServiceMarkdown.FormatSignatureDocumentation(signature, signature.Parameters!.ElementAt(0)));
+    }
+
+    [Fact]
+    public void FormatSignatureDocumentation_ReturnsNullWhenNothingIsDocumented()
+    {
+        Assert.Null(LanguageServiceMarkdown.FormatSignatureDocumentation(Signature("add()"), null));
+    }
+
+    [Fact]
+    public void BuildCompletionDescription_PutsTheDetailIntoACodeBlock()
+    {
+        var item = new CompletionItem
+        {
+            Label = "volume",
+            Detail = "(property) volume: number",
+            Documentation = new StringOrMarkupContent(new MarkupContent
+            {
+                Kind = MarkupKind.Markdown, Value = "How **loud** it is."
+            })
+        };
+
+        Assert.Equal("```typescript\n(property) volume: number\n```\n\nHow **loud** it is.",
+            LanguageServiceMarkdown.BuildCompletionDescription(item, "typescript"));
+    }
+
+    [Fact]
+    public void BuildCompletionDescription_MarksDeprecatedItems()
+    {
+        var item = new CompletionItem
+        {
+            Label = "old",
+            Detail = "function old(): void",
+            Tags = new Container<CompletionItemTag>(CompletionItemTag.Deprecated)
+        };
+
+        Assert.Equal("**Deprecated**\n\n```typescript\nfunction old(): void\n```",
+            LanguageServiceMarkdown.BuildCompletionDescription(item, "typescript"));
+    }
+
+    [Fact]
+    public void BuildCompletionDescription_StaysEmptyWhenTheItemAddsNothing()
+    {
+        //Nothing but the label the completion list already shows, so no tip should open
+        Assert.Null(LanguageServiceMarkdown.BuildCompletionDescription(new CompletionItem { Label = "volume" },
+            "typescript"));
+    }
+
+    [Fact]
+    public void BuildCompletionDescription_UsesLabelDetails()
+    {
+        var item = new CompletionItem
+        {
+            Label = "map",
+            LabelDetails = new CompletionItemLabelDetails
+            {
+                Detail = "(f: fn(T) -> U)",
+                Description = "core::iter"
+            }
+        };
+
+        Assert.Equal("```rust\nmap(f: fn(T) -> U)\n```\n\ncore::iter",
+            LanguageServiceMarkdown.BuildCompletionDescription(item, "rust"));
+    }
+}

--- a/tests/OneWare.Essentials.UnitTests/SemanticVersionTests.cs
+++ b/tests/OneWare.Essentials.UnitTests/SemanticVersionTests.cs
@@ -1,0 +1,75 @@
+using Xunit;
+using OneWare.Essentials.PackageManager;
+
+namespace OneWare.Essentials.UnitTests;
+
+public class SemanticVersionTests
+{
+    [Theory]
+    [InlineData("1.2.3")]
+    [InlineData("1.2")]
+    [InlineData("1.2.3.4")]
+    [InlineData("v1.2.3")]
+    [InlineData("7.0.0-dev.20260707.2")]
+    [InlineData("7.0.1-rc")]
+    [InlineData("1.2.3-beta.1+build.5")]
+    public void TryParse_AcceptsSupportedFormats(string version)
+    {
+        Assert.True(SemanticVersion.TryParse(version, out _));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-version")]
+    [InlineData("1.x.3")]
+    [InlineData("1.2.3-")]
+    public void TryParse_RejectsInvalidFormats(string? version)
+    {
+        Assert.False(SemanticVersion.TryParse(version, out var parsed));
+        Assert.Equal(SemanticVersion.Empty, parsed);
+    }
+
+    [Theory]
+    [InlineData("1.2.3", "1.2.4")]
+    [InlineData("1.2.3", "1.3.0")]
+    [InlineData("1.2.3.1", "1.2.3.2")]
+    [InlineData("7.0.0-dev.20260707.2", "7.0.0")]
+    [InlineData("7.0.0-dev.20260706.1", "7.0.0-dev.20260707.2")]
+    [InlineData("7.0.0-alpha", "7.0.0-beta")]
+    [InlineData("7.0.0-rc.1", "7.0.0-rc.1.1")]
+    [InlineData("7.0.0-1", "7.0.0-alpha")]
+    [InlineData("7.0.0-dev.20260707.2", "7.0.2")]
+    public void CompareTo_OrdersVersions(string lower, string higher)
+    {
+        Assert.True(SemanticVersion.TryParse(lower, out var l));
+        Assert.True(SemanticVersion.TryParse(higher, out var h));
+
+        Assert.True(h > l);
+        Assert.True(l < h);
+        Assert.NotEqual(l, h);
+    }
+
+    [Theory]
+    [InlineData("1.2.3", "1.2.3.0")]
+    [InlineData("1.2", "1.2.0.0")]
+    [InlineData("1.2.3-beta.1+build.5", "1.2.3-beta.1")]
+    public void CompareTo_TreatsEquivalentVersionsAsEqual(string left, string right)
+    {
+        Assert.True(SemanticVersion.TryParse(left, out var l));
+        Assert.True(SemanticVersion.TryParse(right, out var r));
+
+        Assert.Equal(l, r);
+    }
+
+    [Fact]
+    public void IsPrerelease_DetectsSuffix()
+    {
+        Assert.True(SemanticVersion.TryParse("7.0.0-dev.20260707.2", out var prerelease));
+        Assert.True(SemanticVersion.TryParse("7.0.2", out var stable));
+
+        Assert.True(prerelease.IsPrerelease);
+        Assert.False(stable.IsPrerelease);
+    }
+}

--- a/tests/OneWare.PackageManager.UnitTests/PackageServiceTests.cs
+++ b/tests/OneWare.PackageManager.UnitTests/PackageServiceTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using OneWare.Essentials.Enums;
+using OneWare.Essentials.Models;
+using OneWare.Essentials.PackageManager;
+using OneWare.Essentials.Services;
+using OneWare.PackageManager.Installers;
+using OneWare.PackageManager.Services;
+using Xunit;
+
+namespace OneWare.PackageManager.UnitTests;
+
+public class PackageServiceTests
+{
+    private readonly IPackageCatalog _catalog = Substitute.For<IPackageCatalog>();
+    private readonly IPackageDownloader _downloader = Substitute.For<IPackageDownloader>();
+    private readonly IPackageStateStore _stateStore = Substitute.For<IPackageStateStore>();
+    private readonly ISettingsService _settingsService = Substitute.For<ISettingsService>();
+    private readonly IPaths _paths = Substitute.For<IPaths>();
+    private readonly PackageService _service;
+    private readonly string _nativeToolsDirectory =
+        Path.Combine(Path.GetTempPath(), $"test-nativetools-{Guid.NewGuid()}");
+
+    public PackageServiceTests()
+    {
+        _paths.NativeToolsDirectory.Returns(_nativeToolsDirectory);
+        _paths.PackagesDirectory.Returns(_nativeToolsDirectory);
+        _paths.SettingsPath.Returns(Path.Combine(_nativeToolsDirectory, "settings.json"));
+        _settingsService.GetSettingValue<System.Collections.ObjectModel.ObservableCollection<string>>(
+            "PackageManager_Sources").Returns([]);
+        _settingsService.GetSettingValue<bool>("PackageManager_OnlyCustomSources").Returns(false);
+        _catalog.RefreshAsync(Arg.Any<IEnumerable<string[]>>(), Arg.Any<CancellationToken>()).Returns(true);
+
+        _service = new PackageService(_catalog, _downloader, _stateStore, _settingsService,
+            Substitute.For<ILogger>(), Substitute.For<IApplicationStateService>(),
+            Substitute.For<IHttpService>(), _paths, Substitute.For<ICompositeServiceProvider>(),
+            new GenericPackageInstaller());
+    }
+
+    /// <summary>
+    ///     A package installed from a prerelease version must not look uninstalled just because its
+    ///     version string is not a <see cref="Version" />, otherwise it can never be removed again.
+    /// </summary>
+    [Fact]
+    public async Task RefreshAsync_KeepsPrereleaseOnlyPackageRemovable()
+    {
+        SetInstalled(new InstalledPackage("tsgo", "NativeTool", "tsgo", "Binaries", null, null,
+            "7.0.0-dev.20260707.2"));
+        _catalog.Manifests.Returns(new Dictionary<string, Package>());
+
+        await _service.RefreshAsync(true);
+
+        var state = _service.Packages["tsgo"];
+        Assert.Equal(PackageStatus.Installed, state.Status);
+        Assert.Equal("7.0.0-dev.20260707.2", state.InstalledVersion?.Version);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_DropsPackageThatNoRepositoryOffersAnymore()
+    {
+        SetInstalled(new InstalledPackage("tsgo", "NativeTool", "tsgo", "Binaries", null, null,
+            "7.0.0-dev.20260707.2"));
+        _catalog.Manifests.Returns(new Dictionary<string, Package>());
+
+        await _service.RefreshAsync(true);
+
+        Assert.True(await _service.RemoveAsync("tsgo"));
+        Assert.False(_service.Packages.ContainsKey("tsgo"));
+    }
+
+    [Fact]
+    public async Task RemoveAsync_KeepsPackageThatIsStillOffered()
+    {
+        var package = new Package
+        {
+            Id = "still-there",
+            Type = "NativeTool",
+            Name = "Still There",
+            Versions = [new PackageVersion { Version = "1.0.0" }]
+        };
+
+        SetInstalled(new InstalledPackage("still-there", "NativeTool", "Still There", null, null, null, "1.0.0"));
+        _catalog.Manifests.Returns(new Dictionary<string, Package> { ["still-there"] = package });
+
+        await _service.RefreshAsync(true);
+
+        Assert.True(await _service.RemoveAsync("still-there"));
+        Assert.True(_service.Packages.ContainsKey("still-there"));
+        Assert.Null(_service.Packages["still-there"].InstalledVersion);
+    }
+
+    private void SetInstalled(params InstalledPackage[] packages)
+    {
+        _stateStore.LoadAsync().Returns(packages.ToDictionary(x => x.Id));
+    }
+}


### PR DESCRIPTION
## TypeScript language server download was broken

`microsoft/typescript-go` was archived and its `@typescript/native-preview-*` packages stopped at `7.0.0-dev.20260707.2`, which is exactly the version we pinned. The Go port now ships as **TypeScript 7** from the main `microsoft/TypeScript` repo, published as `@typescript/typescript-<platform>` (stable `7.0.2`), with the binary renamed `tsgo` → `tsc`.

The module now points at those packages for all six platform targets (every URL verified reachable), and `LspName`, the settings key and the package id were renamed to match. `tsc --lsp -stdio` was confirmed to still speak LSP.

## Prerelease versions broke package install state

An installed package with a version like `7.0.0-dev.20260707.2` showed up as **Unavailable** with no way to remove it. `Version.TryParse` rejects semver prerelease strings, so the package was never recognised as installed.

- New `SemanticVersion` type used everywhere package versions are parsed or compared.
- Installed-but-unparsable packages stay `Installed` instead of falling back to unavailable.
- `Unavailable` packages that are still installed now offer **Remove**.
- Packages no longer present in the catalog are dropped from the list once removed.

## OmniSharp.Extensions fork

Completion crashed with a `NullReferenceException` for any server returning insert/replace text edits — including `tsc`, where **all 1044** identifier completions use them:

```
System.NullReferenceException
   at TypeAssistanceLanguageService.ConvertCompletionItem(CompletionItem comp, ...)
   at TypeAssistanceLanguageService.ConvertCompletionData(CompletionList list, Int32 offset)
```

`TextEditOrInsertReplaceEditConverter` detected insert/replace edits by checking whether the `insert` property was a *string*, but `insert` is always a Range object — so the branch was dead and every such edit deserialized as a `TextEdit` with a null `Range`. The converter is attached via a type-level `[JsonConverter]` attribute, so it could not be overridden from the client side. Separately, the document diagnostic report converters all threw `NotImplementedException`, which is why pull diagnostics were parsed by hand from raw JSON.

Both are fixed in the OneWare fork (`OneWare.OmniSharp.Extensions.*` 1.0.0), so this PR drops the workarounds: `InsertReplaceSupport` is enabled again, pull diagnostics use the typed `RequestDocumentDiagnostic` API, and the `PrepareRename` error logging that was disabled because of the library is restored. Completion ranges are null guarded regardless, since a malformed edit shouldn't take down completion.

`Microsoft.Extensions.*` props are bumped to 10.0.9 to match the fork's dependencies and avoid `NU1605`.

## Log noise

`tsc` emits a `window/logMessage` at **Info** for every handled request plus periodic snapshot dumps. Only warnings and errors are surfaced now; the rest goes to trace.

## Verification

- Full solution builds with 0 errors and no new warnings.
- Essentials 30/30 and PackageManager 17/17 tests pass, including new regression tests for `SemanticVersion`, the package status logic and insert/replace deserialization. The package tests were confirmed to fail without the fix.
- Exercised against a real `tsc --lsp` server: diagnostics come back as a typed `RelatedFullDocumentDiagnosticReport` with correct items, and all 1044 completion items deserialize with valid insert/replace ranges.

One caveat worth noting: `tsc` returns a full report even when given a `previousResultId`, so the result-id caching path is effectively a no-op with this server and is untested against a server that honours it.
